### PR TITLE
Allow long running child process

### DIFF
--- a/Source/Build/Execute/BuildRunner.h
+++ b/Source/Build/Execute/BuildRunner.h
@@ -193,6 +193,9 @@ namespace Soup::Build::Execute
 				auto stdErr = process->GetStandardError();
 				auto exitCode = process->GetExitCode();
 
+				// Check the result of the monitor
+				callback->VerifyResult();
+
 				// Retrieve the input/output files
 				// TODO: Verify opertation output matches input
 				auto runtimeInput = callback->GetInput();

--- a/Source/Build/Execute/SystemAccessTracker.h
+++ b/Source/Build/Execute/SystemAccessTracker.h
@@ -6,9 +6,18 @@ namespace Soup::Build
 	{
 	public:
 		SystemAccessTracker() :
+			m_activeProcessCount(0),
 			m_input(),
 			m_output()
 		{
+		}
+
+		void VerifyResult()
+		{
+			if (m_activeProcessCount != 0)
+			{
+				Log::Warning("A child process is still running in the background");
+			}
 		}
 
 		std::set<std::string> GetInput()
@@ -24,11 +33,13 @@ namespace Soup::Build
 		void OnInitialize() override final
 		{
 			Log::Diag("SystemAccessTracker::OnInitialize");
+			m_activeProcessCount++;
 		}
 
 		void OnShutdown() override final
 		{
 			Log::Diag("SystemAccessTracker::OnShutdown");
+			m_activeProcessCount--;
 		}
 
 		void OnError(std::string_view message) override final
@@ -1107,6 +1118,7 @@ namespace Soup::Build
 				fileName == "CONOUT$";
 		}
 
+		int m_activeProcessCount;
 		std::set<std::string> m_input;
 		std::set<std::string> m_inputMissing;
 		std::set<std::string> m_output;

--- a/Source/Client/CLI/Commands/VersionCommand.h
+++ b/Source/Client/CLI/Commands/VersionCommand.h
@@ -31,7 +31,7 @@ namespace Soup::Client
 
 			// TODO var version = Assembly.GetExecutingAssembly().GetName().Version;
 			// Log::Message($"{version.Major}.{version.Minor}.{version.Build}");
-			Log::HighPriority("0.8.3");
+			Log::HighPriority("0.8.4");
 		}
 
 	private:

--- a/Source/Client/CLI/Recipe.toml
+++ b/Source/Client/CLI/Recipe.toml
@@ -1,5 +1,5 @@
 Name = "Soup"
-Version = "0.8.3"
+Version = "0.8.4"
 Type = "Executable"
 
 # Ensure the core build extensions are runtime dependencies

--- a/Source/Extensions/RecipeBuild/Tasks/ResolveToolsTask.h
+++ b/Source/Extensions/RecipeBuild/Tasks/ResolveToolsTask.h
@@ -207,7 +207,7 @@ namespace RecipeBuild
 			});
 
 			// Check if we should include pre-release versions
-			bool includePrerelease = true;
+			bool includePrerelease = false;
 			if (includePrerelease)
 			{
 				argumentList.push_back("-prerelease");

--- a/Source/Monitor/Shared/WindowsDetourProcess.h
+++ b/Source/Monitor/Shared/WindowsDetourProcess.h
@@ -319,7 +319,7 @@ namespace Monitor
 				// Read until we get a client and then all clients disconnect
 				m_hasAnyClients = false;
 				m_activeClientCount = 0;
-				while (!m_hasAnyClients || m_activeClientCount > 0)
+				while ((!m_hasAnyClients || m_activeClientCount > 0) && m_processRunning)
 				{
 					// Wait for any of the pipe instances to signal
 					// This indicates that either a client connected to wrote to
@@ -338,7 +338,8 @@ namespace Monitor
 						case WAIT_TIMEOUT:
 							if (!m_processRunning)
 							{
-								throw std::runtime_error("The child process exited unexpectedly");
+								DebugTrace("Main process exited while children still running");
+								continue;
 							}
 							else
 							{


### PR DESCRIPTION
Cl.exe will sometimes spawn the child VCTIP.exe for uploading telemetry that will run beyond the end of the parent process. I used to consider this an error, but with this change it is being converted to a warning, please don't abuse this :(