### PR TITLE
Kill child process

### DIFF
--- a/Source/Client/CLI/Commands/VersionCommand.h
+++ b/Source/Client/CLI/Commands/VersionCommand.h
@@ -31,7 +31,7 @@ namespace Soup::Client
 
 			// TODO var version = Assembly.GetExecutingAssembly().GetName().Version;
 			// Log::Message($"{version.Major}.{version.Minor}.{version.Build}");
-			Log::HighPriority("0.8.4");
+			Log::HighPriority("0.8.5");
 		}
 
 	private:

--- a/Source/Client/CLI/Recipe.toml
+++ b/Source/Client/CLI/Recipe.toml
@@ -1,5 +1,5 @@
 Name = "Soup"
-Version = "0.8.4"
+Version = "0.8.5"
 Type = "Executable"
 
 # Ensure the core build extensions are runtime dependencies

--- a/Source/Monitor/Detours/Module.cpp
+++ b/Source/Monitor/Detours/Module.cpp
@@ -544,10 +544,12 @@ bool ProcessAttach(HMODULE hDll)
 	catch (const std::exception& ex)
 	{
 		EventLogger::WriteError(ex.what());
+		exit(-1234);
 	}
 	catch (...)
 	{
 		EventLogger::WriteError("Unknown error attaching detours");
+		exit(-1234);
 	}
 
 	ThreadAttach(hDll);
@@ -566,10 +568,12 @@ bool ProcessDetach(HMODULE hDll)
 	catch (const std::exception& ex)
 	{
 		EventLogger::WriteError(ex.what());
+		exit(-1234);
 	}
 	catch (...)
 	{
 		EventLogger::WriteError("Unknown error detaching detours");
+		exit(-1234);
 	}
 
 	EventLogger::Shutdown();


### PR DESCRIPTION
When a child process has a Detour error I now kill it to fail early. This will also cause long running children to kill themselves to prevent locking the detour dlls.