### PR TITLE
Combine Dependencies into Recipe Table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 *.user
 .vscode/ipch/
 packages/
+bin/
+obj/
 
-# Build
+# Soup
 /out/
 
 # Wix

--- a/Docs/Samples/Simple-Build-Extension.md
+++ b/Docs/Samples/Simple-Build-Extension.md
@@ -11,7 +11,7 @@ Type = "DynamicLibrary"
 Version = "1.0.0"
 Dependencies = [
     "Opal@0.1.7",
-    "Soup.Build@0.3.0",
+    "Soup.Build@0.4.1",
     "Soup.Build.Utilities@0.3.0",
 ]
 

--- a/Samples/C++/ParseJsonFile/Recipe.toml
+++ b/Samples/C++/ParseJsonFile/Recipe.toml
@@ -2,9 +2,11 @@ Name = "ParseJsonFile"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
-	"json11@1.0.1",
-]
 Source = [
 	"Main.cpp",
+]
+
+[Dependencies]
+Runtime = [
+	"json11@1.0.1",
 ]

--- a/Samples/C++/SimpleBuildExtension/Executable/Recipe.toml
+++ b/Samples/C++/SimpleBuildExtension/Executable/Recipe.toml
@@ -2,9 +2,11 @@ Name = "SimpleBuildExtension.Executable"
 Language = "C++"
 Type = "Executable"
 Version = "1.0.0"
-DevDependencies = [
-	"../Extension"
-]
 Source = [
 	"Main.cpp"
+]
+
+[Dependencies]
+Build = [
+	"../Extension/"
 ]

--- a/Samples/C++/SimpleBuildExtension/Extension/Recipe.toml
+++ b/Samples/C++/SimpleBuildExtension/Extension/Recipe.toml
@@ -2,12 +2,13 @@ Name = "SimpleBuildExtension"
 Language = "C++"
 Type = "DynamicLibrary"
 Version = "1.0.0"
-Dependencies = [
-	"Opal@0.1.8",
-	"Soup.Build@0.4.0",
-	"Soup.Build.Utilities@0.4.0",
-]
-
 Source = [
 	"Register.cpp"
+]
+
+[Dependencies]
+Runtime = [
+	"Opal@0.1.8",
+	"Soup.Build@0.4.1",
+	"Soup.Build.Utilities@0.4.1",
 ]

--- a/Samples/C++/StaticLibraryReference/MyApplication/Recipe.toml
+++ b/Samples/C++/StaticLibraryReference/MyApplication/Recipe.toml
@@ -2,9 +2,11 @@ Name = "MyApplication"
 Language = "C++"
 Type = "Executable"
 Version = "1.0.0"
-Dependencies = [
-	"../MyLibrary/"
-]
 Source = [
 	"Main.cpp"
+]
+
+[Dependencies]
+Runtime = [
+	"../MyLibrary/"
 ]

--- a/Scripts/soupd.cmd
+++ b/Scripts/soupd.cmd
@@ -1,6 +1,6 @@
 @echo off
 SET ScriptsDir=%~dp0
-SET OutDir=%ClientDir%..\out
+SET OutDir=%ScriptsDir%..\out
 SET RunDir=%OutDir%\run
 REM - Use a copy of the final binary in case we are re-buiding itself
 robocopy %OutDir%\Soup\MSVC\debug\win32\x64\bin\ %RunDir%\ /MIR

--- a/Source/Build/Contracts/Recipe.toml
+++ b/Source/Build/Contracts/Recipe.toml
@@ -2,9 +2,10 @@ Name = "Soup.Build"
 Language = "C++"
 Description = """The core Soup Build Contracts used to define the stable Binary Interface 
 layer between the Build Generate engine and the Extensions."""
-Version = "0.4.0"
-Dependencies = [
+Version = "0.4.1"
+Interface = "Module.cpp"
+
+[Dependencies]
+Runtime = [
 	"Opal@0.1.8",
 ]
-
-Interface = "Module.cpp"

--- a/Source/Build/Runtime/Recipe.toml
+++ b/Source/Build/Runtime/Recipe.toml
@@ -3,27 +3,30 @@ Language = "C++"
 Description = """The Build Runtime that contains the generate and evaluate engines that is responsible for Execution of 
 the minimum set of Build Operations for a fully consistent build."""
 Version = "0.1.0"
-Dependencies = [
-	"json11@1.0.1",
-	"Opal@0.1.8",
-	"Soup.Build@0.4.0",
-	"Soup.Build.Utilities@0.4.0",
-	"../../Monitor/Shared/",
-]
 Interface = "Source/Module.cpp"
 Source = [
 	"Source/Contracts/Value.cpp",
 ]
 
-DevDependencies = [
-	"../../Extensions/TestBuild/",
+[Dependencies]
+Runtime = [
+	"json11@1.0.1",
+	"Opal@0.1.8",
+	"Soup.Build@0.4.1",
+	"Soup.Build.Utilities@0.4.1",
+	"../../Monitor/Shared/",
+]
+Build = [
+	#"../../Extensions/TestBuild/",
+]
+Test = [
 	"Soup.Test.Assert@0.1.7",
 ]
 
-	[Tests]
-	Source = [
-		"UnitTests/gen/Main.cpp"
-	]
-	IncludePaths = [
-		"UnitTests/",
-	]
+[Tests]
+Source = [
+	"UnitTests/gen/Main.cpp"
+]
+IncludePaths = [
+	"UnitTests/",
+]

--- a/Source/Build/Runtime/UnitTests/Recipe.toml
+++ b/Source/Build/Runtime/UnitTests/Recipe.toml
@@ -2,14 +2,16 @@ Name = "Soup.Build.Runtime.UnitTests"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
-	"json11@1.0.1",
-	"Soup.Test.Assert@0.1.7",
-	"../Runtime/",
-]
 Source = [
 	"gen/Main.cpp",
 ]
 IncludePaths = [
 	"./",
+]
+
+[Dependencies]
+Runtime = [
+	"json11@1.0.1",
+	"Soup.Test.Assert@0.1.7",
+	"../Runtime/",
 ]

--- a/Source/Build/Utilities.UnitTests/Recipe.toml
+++ b/Source/Build/Utilities.UnitTests/Recipe.toml
@@ -2,13 +2,15 @@ Name = "Soup.Build.Utilities.UnitTests"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
-	"../Utilities/",
-	"Soup.Test.Assert@0.1.7",
-]
 Source = [
 	"gen/Main.cpp"
 ]
 IncludePaths = [
 	"./",
+]
+
+[Dependencies]
+Runtime = [
+	"../Utilities/",
+	"Soup.Test.Assert@0.1.7",
 ]

--- a/Source/Build/Utilities/Recipe.toml
+++ b/Source/Build/Utilities/Recipe.toml
@@ -1,13 +1,14 @@
 Name = "Soup.Build.Utilities"
 Language = "C++"
 Description = """A set of utility classes that are commonly needed to help make writing a Build Extension easier."""
-Version = "0.4.0"
-Dependencies = [
-	"Opal@0.1.8",
-	"Soup.Build@0.4.0",
-]
-
+Version = "0.4.1"
 Interface = "Module.cpp"
 Source = [
 	"Wrapper/ValueWrapper.cpp",
+]
+
+[Dependencies]
+Runtime = [
+	"Opal@0.1.8",
+	"Soup.Build@0.4.1",
 ]

--- a/Source/Client/CLI/Recipe.toml
+++ b/Source/Client/CLI/Recipe.toml
@@ -3,15 +3,6 @@ Language = "C++"
 Version = "0.10.0"
 Type = "Executable"
 
-# Ensure the core build extensions are runtime dependencies
-Dependencies = [
-	"../Core/",
-	"../../Tools/Copy/",
-	"../../Tools/Mkdir/",
-	"../../Extensions/Cpp/Extension/",
-	"../../Extensions/CSharp/Extension/",
-	"../../Monitor/Shared/",
-]
 RuntimeDependencies = [
 	"LocalUserConfig.json",
 ]
@@ -23,15 +14,27 @@ IncludePaths = [
 	"Source/Options/",
 ]
 
-DevDependencies = [
+[Dependencies]
+# Ensure the core build extensions are runtime dependencies
+Runtime = [
+	"../Core/",
+	"../../Tools/Copy/",
+	"../../Tools/Mkdir/",
+	"../../Extensions/Cpp/Extension/",
+	"../../Extensions/CSharp/Extension/",
+	"../../Monitor/Shared/",
+]
+Build = [
 	# TODO: "../../Extensions/TestBuild/",
+]
+Test = [
 	"Soup.Test.Assert@0.1.7",
 ]
 
-	[Tests]
-	Source = [
-		"UnitTests/gen/Main.cpp"
-	]
-	IncludePaths = [
-		"UnitTests/",
-	]
+[Tests]
+Source = [
+	"UnitTests/gen/Main.cpp"
+]
+IncludePaths = [
+	"UnitTests/",
+]

--- a/Source/Client/CLI/Recipe.toml
+++ b/Source/Client/CLI/Recipe.toml
@@ -1,6 +1,6 @@
 Name = "Soup"
 Language = "C++"
-Version = "0.9.7"
+Version = "0.10.0"
 Type = "Executable"
 
 # Ensure the core build extensions are runtime dependencies

--- a/Source/Client/CLI/Source/Commands/InitializeCommand.h
+++ b/Source/Client/CLI/Source/Commands/InitializeCommand.h
@@ -41,6 +41,7 @@ namespace Soup::Client
 				"C++",
 				SemanticVersion(1, 0, 0),
 				std::nullopt,
+				std::nullopt,
 				std::nullopt);
 
 			// TODO: 

--- a/Source/Client/CLI/Source/Commands/VersionCommand.h
+++ b/Source/Client/CLI/Source/Commands/VersionCommand.h
@@ -31,7 +31,7 @@ namespace Soup::Client
 
 			// TODO var version = Assembly.GetExecutingAssembly().GetName().Version;
 			// Log::Message($"{version.Major}.{version.Minor}.{version.Build}");
-			Log::HighPriority("0.9.7");
+			Log::HighPriority("0.10.0");
 		}
 
 	private:

--- a/Source/Client/Core/Recipe.toml
+++ b/Source/Client/Core/Recipe.toml
@@ -1,16 +1,6 @@
 Name = "Soup.Core"
 Language = "C++"
 Version = "0.1.0"
-
-Dependencies = [
-	"../../../Dependencies/LzmaSdk/CPP/Library/",
-	"json11@1.0.1",
-	"toml11@1.0.1",
-	"../OpalExtensions/",
-	"Soup.Build@0.4.0",
-	"Soup.Build.Utilities@0.4.0",
-	"../../Build/Runtime/",
-]
 Defines = [
 	# "LOCAL_DEBUG",
 ]
@@ -21,15 +11,27 @@ IncludePaths = [
 	"Source/Utils/",
 ]
 
-DevDependencies = [
-	"../../Extensions/TestBuild/",
+[Dependencies]
+Runtime = [
+	"../../../Dependencies/LzmaSdk/CPP/Library/",
+	"json11@1.0.1",
+	"toml11@1.0.1",
+	"../OpalExtensions/",
+	"Soup.Build@0.4.1",
+	"Soup.Build.Utilities@0.4.1",
+	"../../Build/Runtime/",
+]
+Build = [
+	# "../../Extensions/TestBuild/",
+]
+Test = [
 	"Soup.Test.Assert@0.1.7",
 ]
 
-	[Tests]
-	Source = [
-		"UnitTests/gen/Main.cpp"
-	]
-	IncludePaths = [
-		"UnitTests/",
-	]
+[Tests]
+Source = [
+	"UnitTests/gen/Main.cpp"
+]
+IncludePaths = [
+	"UnitTests/",
+]

--- a/Source/Client/Core/Source/Package/PackageManager.h
+++ b/Source/Client/Core/Source/Package/PackageManager.h
@@ -90,9 +90,9 @@ namespace Soup
 
 				// Check if the package is already installed
 				auto packageNameNormalized = ToUpper(packageName);
-				if (recipe.HasDependencies())
+				if (recipe.HasRuntimeDependencies())
 				{
-					for (auto& dependency : recipe.GetDependencies())
+					for (auto& dependency : recipe.GetRuntimeDependencies())
 					{
 						if (!dependency.IsLocal())
 						{
@@ -128,11 +128,11 @@ namespace Soup
 				// Register the package in the recipe
 				Log::Info("Adding reference to recipe");
 				auto dependencies = std::vector<PackageReference>();
-				if (recipe.HasDependencies())
-					dependencies = recipe.GetDependencies();
+				if (recipe.HasRuntimeDependencies())
+					dependencies = recipe.GetRuntimeDependencies();
 
 				dependencies.push_back(targetPackageReference);
-				recipe.SetDependencies(dependencies);
+				recipe.SetRuntimeDependencies(dependencies);
 
 				// Save the state of the recipe
 				RecipeExtensions::SaveToFile(recipePath, recipe);
@@ -471,9 +471,9 @@ namespace Soup
 				throw std::runtime_error("Could not load the recipe file.");
 			}
 	
-			if (recipe.HasDependencies())
+			if (recipe.HasRuntimeDependencies())
 			{
-				for (auto& dependency : recipe.GetDependencies())
+				for (auto& dependency : recipe.GetRuntimeDependencies())
 				{
 					// If local then check children for external package references
 					// Otherwise install the external package reference and its dependencies
@@ -496,9 +496,9 @@ namespace Soup
 				}
 			}
 
-			if (recipe.HasDevDependencies())
+			if (recipe.HasBuildDependencies())
 			{
-				for (auto& dependency : recipe.GetDevDependencies())
+				for (auto& dependency : recipe.GetBuildDependencies())
 				{
 					// If local then check children for external package references
 					// Otherwise install the external package reference and its dependencies

--- a/Source/Client/Core/UnitTests/Package/RecipeTests.h
+++ b/Source/Client/Core/UnitTests/Package/RecipeTests.h
@@ -17,8 +17,9 @@ namespace Soup::Build::UnitTests
 			Assert::AreEqual<std::string_view>("", uut.GetName(), "Verify name matches expected.");
 			Assert::AreEqual<std::string_view>("", uut.GetLanguage(), "Verify language matches expected.");
 			Assert::IsFalse(uut.HasVersion(), "Verify has no version.");
-			Assert::IsFalse(uut.HasDependencies(), "Verify has no dependencies.");
-			Assert::IsFalse(uut.HasDevDependencies(), "Verify has no dev dependencies.");
+			Assert::IsFalse(uut.HasRuntimeDependencies(), "Verify has no runtime dependencies.");
+			Assert::IsFalse(uut.HasBuildDependencies(), "Verify has no build dependencies.");
+			Assert::IsFalse(uut.HasTestDependencies(), "Verify has no test dependencies.");
 		}
 
 		[[Fact]]
@@ -29,30 +30,40 @@ namespace Soup::Build::UnitTests
 				"C++",
 				SemanticVersion(1, 2, 3),
 				std::vector<PackageReference>({
-					PackageReference(Path("../OtherPackage")),
+					PackageReference(Path("../OtherPackage/")),
 				}),
 				std::vector<PackageReference>({
-					PackageReference(Path("../DevTask")),
+					PackageReference(Path("../DevTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
 				}));
 
 			Assert::AreEqual<std::string_view>("MyPackage", uut.GetName(), "Verify name matches expected.");
 			Assert::AreEqual<std::string_view>("C++", uut.GetLanguage(), "Verify language matches expected.");
 			Assert::IsTrue(uut.HasVersion(), "Verify has version.");
 			Assert::AreEqual(SemanticVersion(1, 2, 3), uut.GetVersion(), "Verify version is correct.");
-			Assert::IsTrue(uut.HasDependencies(), "Verify has dependencies.");
+			Assert::IsTrue(uut.HasRuntimeDependencies(), "Verify has runtime dependencies.");
 			Assert::AreEqual(
 				std::vector<PackageReference>({
-					PackageReference(Path(Path("../OtherPackage"))),
+					PackageReference(Path(Path("../OtherPackage/"))),
 				}),
-				uut.GetDependencies(),
-				"Verify dependencies are correct.");
-			Assert::IsTrue(uut.HasDevDependencies(), "Verify has dev dependencies.");
+				uut.GetRuntimeDependencies(),
+				"Verify runtime dependencies are correct.");
+			Assert::IsTrue(uut.HasBuildDependencies(), "Verify has build dependencies.");
 			Assert::AreEqual(
 				std::vector<PackageReference>({
-					PackageReference(Path(Path("../DevTask"))),
+					PackageReference(Path(Path("../DevTask/"))),
 				}),
-				uut.GetDevDependencies(),
-				"Verify dev dependencies are correct.");
+				uut.GetBuildDependencies(),
+				"Verify build dependencies are correct.");
+			Assert::IsTrue(uut.HasTestDependencies(), "Verify has test dependencies.");
+			Assert::AreEqual(
+				std::vector<PackageReference>({
+					PackageReference(Path(Path("../TestPackage/"))),
+				}),
+				uut.GetTestDependencies(),
+				"Verify test dependencies are correct.");
 		}
 
 		[[Fact]]
@@ -71,10 +82,13 @@ namespace Soup::Build::UnitTests
 				"C++",
 				SemanticVersion(1, 2, 3),
 				std::vector<PackageReference>({
-					PackageReference(Path("../OtherPackage")),
+					PackageReference(Path("../OtherPackage/")),
 				}),
 				std::vector<PackageReference>({
-					PackageReference(Path("../BuildTask")),
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
 				}));
 
 			Assert::AreEqual(
@@ -83,10 +97,13 @@ namespace Soup::Build::UnitTests
 					"C++",
 					SemanticVersion(1, 2, 3),
 					std::vector<PackageReference>({
-						PackageReference(Path("../OtherPackage")),
+						PackageReference(Path("../OtherPackage/")),
 					}),
 					std::vector<PackageReference>({
-						PackageReference(Path("../BuildTask")),
+						PackageReference(Path("../BuildTask/")),
+					}),
+					std::vector<PackageReference>({
+						PackageReference(Path("../TestPackage/")),
 					})),
 				uut,
 				"Verify equal.");
@@ -100,10 +117,13 @@ namespace Soup::Build::UnitTests
 				"C++",
 				SemanticVersion(1, 2, 3),
 				std::vector<PackageReference>({
-					PackageReference(Path("../OtherPackage")),
+					PackageReference(Path("../OtherPackage/")),
 				}),
 				std::vector<PackageReference>({
-					PackageReference(Path("../BuildTask")),
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
 				}));
 
 			Assert::AreNotEqual(
@@ -112,10 +132,13 @@ namespace Soup::Build::UnitTests
 					"C++",
 					SemanticVersion(1, 2, 3),
 					std::vector<PackageReference>({
-						PackageReference(Path("../OtherPackage")),
+						PackageReference(Path("../OtherPackage/")),
 					}),
 					std::vector<PackageReference>({
-						PackageReference(Path("../BuildTask")),
+						PackageReference(Path("../BuildTask/")),
+					}),
+					std::vector<PackageReference>({
+						PackageReference(Path("../TestPackage/")),
 					})),
 				uut,
 				"Verify are not equal.");
@@ -129,10 +152,13 @@ namespace Soup::Build::UnitTests
 				"C++",
 				SemanticVersion(1, 2, 3),
 				std::vector<PackageReference>({
-					PackageReference(Path("../OtherPackage")),
+					PackageReference(Path("../OtherPackage/")),
 				}),
 				std::vector<PackageReference>({
-					PackageReference(Path("../BuildTask")),
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
 				}));
 
 			Assert::AreNotEqual(
@@ -141,10 +167,13 @@ namespace Soup::Build::UnitTests
 					"C#",
 					SemanticVersion(1, 2, 3),
 					std::vector<PackageReference>({
-						PackageReference(Path("../OtherPackage")),
+						PackageReference(Path("../OtherPackage/")),
 					}),
 					std::vector<PackageReference>({
-						PackageReference(Path("../BuildTask")),
+						PackageReference(Path("../BuildTask/")),
+					}),
+					std::vector<PackageReference>({
+						PackageReference(Path("../TestPackage/")),
 					})),
 				uut,
 				"Verify are not equal.");
@@ -158,10 +187,13 @@ namespace Soup::Build::UnitTests
 				"C++",
 				SemanticVersion(1, 2, 3),
 				std::vector<PackageReference>({
-					PackageReference(Path("../OtherPackage")),
+					PackageReference(Path("../OtherPackage/")),
 				}),
 				std::vector<PackageReference>({
-					PackageReference(Path("../BuildTask")),
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
 				}));
 
 			Assert::AreNotEqual(
@@ -170,10 +202,13 @@ namespace Soup::Build::UnitTests
 					"C++",
 					SemanticVersion(11, 2, 3),
 					std::vector<PackageReference>({
-						PackageReference(Path("../OtherPackage")),
+						PackageReference(Path("../OtherPackage/")),
 					}),
 					std::vector<PackageReference>({
-						PackageReference(Path("../BuildTask")),
+						PackageReference(Path("../BuildTask/")),
+					}),
+					std::vector<PackageReference>({
+						PackageReference(Path("../TestPackage/")),
 					})),
 				uut,
 				"Verify are not equal.");
@@ -187,10 +222,13 @@ namespace Soup::Build::UnitTests
 				"C++",
 				SemanticVersion(1, 2, 3),
 				std::vector<PackageReference>({
-					PackageReference(Path("../OtherPackage")),
+					PackageReference(Path("../OtherPackage/")),
 				}),
 				std::vector<PackageReference>({
-					PackageReference(Path("../BuildTask")),
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
 				}));
 
 			Assert::AreNotEqual(
@@ -199,27 +237,33 @@ namespace Soup::Build::UnitTests
 					"C++",
 					std::nullopt,
 					std::vector<PackageReference>({
-						PackageReference(Path("../OtherPackage")),
+						PackageReference(Path("../OtherPackage/")),
 					}),
 					std::vector<PackageReference>({
-						PackageReference(Path("../BuildTask")),
+						PackageReference(Path("../BuildTask/")),
+					}),
+					std::vector<PackageReference>({
+						PackageReference(Path("../TestPackage/")),
 					})),
 				uut,
 				"Verify are not equal.");
 		}
 
 		[[Fact]]
-		void OperatorNotEqualDependencies()
+		void OperatorNotEqualRuntimeDependencies()
 		{
 			auto uut = Recipe(
 				"MyPackage",
 				"C++",
 				SemanticVersion(1, 2, 3),
 				std::vector<PackageReference>({
-					PackageReference(Path("../OtherPackage")),
+					PackageReference(Path("../OtherPackage/")),
 				}),
 				std::vector<PackageReference>({
-					PackageReference(Path("../BuildTask")),
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
 				}));
 
 			Assert::AreNotEqual(
@@ -230,24 +274,30 @@ namespace Soup::Build::UnitTests
 					std::vector<PackageReference>({
 					}),
 					std::vector<PackageReference>({
-						PackageReference(Path("../BuildTask")),
+						PackageReference(Path("../BuildTask/")),
+					}),
+					std::vector<PackageReference>({
+						PackageReference(Path("../TestPackage/")),
 					})),
 				uut,
 				"Verify are not equal.");
 		}
 
 		[[Fact]]
-		void OperatorNotEqualNoDependencies()
+		void OperatorNotEqualNoRuntimeDependencies()
 		{
 			auto uut = Recipe(
 				"MyPackage",
 				"C++",
 				SemanticVersion(1, 2, 3),
 				std::vector<PackageReference>({
-					PackageReference(Path("../OtherPackage")),
+					PackageReference(Path("../OtherPackage/")),
 				}),
 				std::vector<PackageReference>({
-					PackageReference(Path("../BuildTask")),
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
 				}));
 
 			Assert::AreNotEqual(
@@ -257,24 +307,30 @@ namespace Soup::Build::UnitTests
 					SemanticVersion(1, 2, 3),
 					std::nullopt,
 					std::vector<PackageReference>({
-						PackageReference(Path("../BuildTask")),
+						PackageReference(Path("../BuildTask/")),
+					}),
+					std::vector<PackageReference>({
+						PackageReference(Path("../TestPackage/")),
 					})),
 				uut,
 				"Verify are not equal.");
 		}
 
 		[[Fact]]
-		void OperatorNotEqualDevDependencies()
+		void OperatorNotEqualBuildDependencies()
 		{
 			auto uut = Recipe(
 				"MyPackage",
 				"C++",
 				SemanticVersion(1, 2, 3),
 				std::vector<PackageReference>({
-					PackageReference(Path("../OtherPackage")),
+					PackageReference(Path("../OtherPackage/")),
 				}),
 				std::vector<PackageReference>({
-					PackageReference(Path("../BuildTask")),
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
 				}));
 
 			Assert::AreNotEqual(
@@ -283,7 +339,77 @@ namespace Soup::Build::UnitTests
 					"C++",
 					SemanticVersion(1, 2, 3),
 					std::vector<PackageReference>({
-						PackageReference(Path("../OtherPackage")),
+						PackageReference(Path("../OtherPackage/")),
+					}),
+					std::vector<PackageReference>({
+					}),
+					std::vector<PackageReference>({
+						PackageReference(Path("../TestPackage/")),
+					})),
+				uut,
+				"Verify are not equal.");
+		}
+
+		[[Fact]]
+		void OperatorNotEqualNoBuildDependencies()
+		{
+			auto uut = Recipe(
+				"MyPackage",
+				"C++",
+				SemanticVersion(1, 2, 3),
+				std::vector<PackageReference>({
+					PackageReference(Path("../OtherPackage/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
+				}));
+
+			Assert::AreNotEqual(
+				Recipe(
+					"MyPackage",
+					"C++",
+					SemanticVersion(1, 2, 3),
+					std::vector<PackageReference>({
+						PackageReference(Path("../OtherPackage/")),
+					}),
+					std::nullopt,
+					std::vector<PackageReference>({
+						PackageReference(Path("../TestPackage/")),
+					})),
+				uut,
+				"Verify are not equal.");
+		}
+
+		[[Fact]]
+		void OperatorNotEqualTestDependencies()
+		{
+			auto uut = Recipe(
+				"MyPackage",
+				"C++",
+				SemanticVersion(1, 2, 3),
+				std::vector<PackageReference>({
+					PackageReference(Path("../OtherPackage/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
+				}));
+
+			Assert::AreNotEqual(
+				Recipe(
+					"MyPackage",
+					"C++",
+					SemanticVersion(1, 2, 3),
+					std::vector<PackageReference>({
+						PackageReference(Path("../OtherPackage/")),
+					}),
+					std::vector<PackageReference>({
+						PackageReference(Path("../BuildTask/")),
 					}),
 					std::vector<PackageReference>({
 					})),
@@ -292,17 +418,20 @@ namespace Soup::Build::UnitTests
 		}
 
 		[[Fact]]
-		void OperatorNotEqualNoDevDependencies()
+		void OperatorNotEqualNoTestDependencies()
 		{
 			auto uut = Recipe(
 				"MyPackage",
 				"C++",
 				SemanticVersion(1, 2, 3),
 				std::vector<PackageReference>({
-					PackageReference(Path("../OtherPackage")),
+					PackageReference(Path("../OtherPackage/")),
 				}),
 				std::vector<PackageReference>({
-					PackageReference(Path("../BuildTask")),
+					PackageReference(Path("../BuildTask/")),
+				}),
+				std::vector<PackageReference>({
+					PackageReference(Path("../TestPackage/")),
 				}));
 
 			Assert::AreNotEqual(
@@ -311,7 +440,10 @@ namespace Soup::Build::UnitTests
 					"C++",
 					SemanticVersion(1, 2, 3),
 					std::vector<PackageReference>({
-						PackageReference(Path("../OtherPackage")),
+						PackageReference(Path("../OtherPackage/")),
+					}),
+					std::vector<PackageReference>({
+						PackageReference(Path("../BuildTask/")),
 					}),
 					std::nullopt),
 				uut,

--- a/Source/Client/Core/UnitTests/Package/RecipeTomlTests.h
+++ b/Source/Client/Core/UnitTests/Package/RecipeTomlTests.h
@@ -67,8 +67,10 @@ namespace Soup::Build::UnitTests
 					Name="MyPackage"
 					Language="C++"
 					Version="1.2.3"
-					Dependencies=[]
-					DevDependencies=[]
+					[Dependencies]
+					Runtime=[]
+					Build=[]
+					Test=[]
 				)");
 			auto actual = Recipe(RecipeToml::Deserialize(recipeFile, recipe));
 
@@ -141,8 +143,10 @@ Language = "C++"
 R"(Name = "MyPackage"
 Language = "C++"
 Version = "1.2.3"
-Dependencies = []
-DevDependencies = []
+[Dependencies]
+Runtime = []
+Build = []
+Test = []
 )";
 
 			VerifyTomlEquals(expected, actual.str(), "Verify matches expected.");

--- a/Source/Client/Core/UnitTests/gen/Package/RecipeTests.gen.h
+++ b/Source/Client/Core/UnitTests/gen/Package/RecipeTests.gen.h
@@ -14,10 +14,12 @@ TestState RunRecipeTests()
 	state += Soup::Test::RunTest(className, "OperatorNotEqualLanguage", [&testClass]() { testClass->OperatorNotEqualLanguage(); });
 	state += Soup::Test::RunTest(className, "OperatorNotEqualVersion", [&testClass]() { testClass->OperatorNotEqualVersion(); });
 	state += Soup::Test::RunTest(className, "OperatorNotEqualNoVersion", [&testClass]() { testClass->OperatorNotEqualNoVersion(); });
-	state += Soup::Test::RunTest(className, "OperatorNotEqualDependencies", [&testClass]() { testClass->OperatorNotEqualDependencies(); });
-	state += Soup::Test::RunTest(className, "OperatorNotEqualNoDependencies", [&testClass]() { testClass->OperatorNotEqualNoDependencies(); });
-	state += Soup::Test::RunTest(className, "OperatorNotEqualDevDependencies", [&testClass]() { testClass->OperatorNotEqualDevDependencies(); });
-	state += Soup::Test::RunTest(className, "OperatorNotEqualNoDevDependencies", [&testClass]() { testClass->OperatorNotEqualNoDevDependencies(); });
+	state += Soup::Test::RunTest(className, "OperatorNotEqualRuntimeDependencies", [&testClass]() { testClass->OperatorNotEqualRuntimeDependencies(); });
+	state += Soup::Test::RunTest(className, "OperatorNotEqualNoRuntimeDependencies", [&testClass]() { testClass->OperatorNotEqualNoRuntimeDependencies(); });
+	state += Soup::Test::RunTest(className, "OperatorNotEqualBuildDependencies", [&testClass]() { testClass->OperatorNotEqualBuildDependencies(); });
+	state += Soup::Test::RunTest(className, "OperatorNotEqualNoBuildDependencies", [&testClass]() { testClass->OperatorNotEqualNoBuildDependencies(); });
+	state += Soup::Test::RunTest(className, "OperatorNotEqualTestDependencies", [&testClass]() { testClass->OperatorNotEqualTestDependencies(); });
+	state += Soup::Test::RunTest(className, "OperatorNotEqualNoTestDependencies", [&testClass]() { testClass->OperatorNotEqualNoTestDependencies(); });
 
 	return state;
 }

--- a/Source/Client/OpalExtensions/Recipe.toml
+++ b/Source/Client/OpalExtensions/Recipe.toml
@@ -2,11 +2,13 @@ Name = "Opal.Extensions"
 Language = "C++"
 Version = "0.1.0"
 Interface = "Module.cpp"
-Dependencies = [
+Defines = [
+	# "ENABLE_FIDDLER_PROXY",
+]
+
+[Dependencies]
+Runtime = [
 	"../../../Dependencies/cpp-httplib/",
 	# "httplib@1.0.0",
 	"Opal@0.1.8",
-]
-Defines = [
-	# "ENABLE_FIDDLER_PROXY",
 ]

--- a/Source/Extensions/CSharp/Compiler/Core.UnitTests/Recipe.toml
+++ b/Source/Extensions/CSharp/Compiler/Core.UnitTests/Recipe.toml
@@ -2,14 +2,16 @@ Name = "Soup.CSharp.Compiler.Core.UnitTests"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
-	"../Core/",
-	"../../../../Build/Runtime/",
-	"Soup.Test.Assert@0.1.7",
-]
 Source = [
 	"gen/Main.cpp"
 ]
 IncludePaths = [
 	"./",
+]
+
+[Dependencies]
+Runtime = [
+	"../Core/",
+	"../../../../Build/Runtime/",
+	"Soup.Test.Assert@0.1.7",
 ]

--- a/Source/Extensions/CSharp/Compiler/Core/Recipe.toml
+++ b/Source/Extensions/CSharp/Compiler/Core/Recipe.toml
@@ -1,9 +1,10 @@
 Name = "Soup.CSharp.Compiler"
 Language = "C++"
 Version = "0.3.0"
-Dependencies = [
-	"Opal@0.1.8",
-	"Soup.Build.Utilities@0.4.0",
-]
-
 Interface = "Module.cpp"
+
+[Dependencies]
+Runtime = [
+	"Opal@0.1.8",
+	"Soup.Build.Utilities@0.4.1",
+]

--- a/Source/Extensions/CSharp/Extension.UnitTests/Recipe.toml
+++ b/Source/Extensions/CSharp/Extension.UnitTests/Recipe.toml
@@ -2,15 +2,17 @@ Name = "Soup.CSharp.UnitTests"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
-	"json11@1.0.1",
-	"../../../../Dependencies/SoupTest/Assert/",
-	"../../../Build/Runtime/",
-	"../Extension/",
-]
 Source = [
 	"gen/Main.cpp"
 ]
 IncludePaths = [
 	"./"
+]
+
+[Dependencies]
+Runtime = [
+	"json11@1.0.1",
+	"../../../../Dependencies/SoupTest/Assert/",
+	"../../../Build/Runtime/",
+	"../Extension/",
 ]

--- a/Source/Extensions/CSharp/Extension/Recipe.toml
+++ b/Source/Extensions/CSharp/Extension/Recipe.toml
@@ -2,25 +2,27 @@ Name = "Soup.CSharp"
 Language = "C++"
 Type = "DynamicLibrary"
 Version = "1.0.0"
-Dependencies = [
-	"Opal@0.1.8",
-	"../Compiler/Core/",
-]
-
 Interface = "Module.cpp"
 Source = [
 	"RegisterBuildExtension.cpp",
 ]
 
-DevDependencies = [
+[Dependencies]
+Runtime = [
+	"Opal@0.1.8",
+	"../Compiler/Core/",
+]
+Build = [
 	# TODO "../../TestBuild/",
+]
+Test = [
 	"Soup.Test.Assert@0.1.7",
 ]
 
-	[Tests]
-	Source = [
-		"../Extension.UnitTests/gen/Main.cpp",
-	]
-	IncludePaths = [
-		"../Extension.UnitTests/",
-	]
+[Tests]
+Source = [
+	"../Extension.UnitTests/gen/Main.cpp",
+]
+IncludePaths = [
+	"../Extension.UnitTests/",
+]

--- a/Source/Extensions/CSharp/Extension/Tasks/ResolveDependenciesTask.h
+++ b/Source/Extensions/CSharp/Extension/Tasks/ResolveDependenciesTask.h
@@ -79,34 +79,38 @@ namespace Soup::CSharp
 			if (activeState.HasValue("Dependencies"))
 			{
 				auto dependenciesTable = activeState.GetValue("Dependencies").AsTable();
-				auto buildTable = activeState.EnsureValue("Build").EnsureTable();
-
-				for (auto& dependencyName : dependenciesTable.GetValueKeyList().CopyAsStringVector())
+				if (dependenciesTable.HasValue("Runtime"))
 				{
-					// Combine the core dependency build inputs for the core build task
-					buildState.LogInfo("Combine Dependency: " + dependencyName);
-					auto dependencyTable = dependenciesTable.GetValue(dependencyName).AsTable();
+					auto runtimeDependenciesTable = dependenciesTable.GetValue("Runtime").AsTable();
+					auto buildTable = activeState.EnsureValue("Build").EnsureTable();
 
-					if (dependencyTable.HasValue("Build"))
+					for (auto& dependencyName : runtimeDependenciesTable.GetValueKeyList().CopyAsStringVector())
 					{
-						auto dependencyBuildTable = dependencyTable.GetValue("Build").AsTable();
+						// Combine the core dependency build inputs for the core build task
+						buildState.LogInfo("Combine Runtime Dependency: " + dependencyName);
+						auto dependencyTable = runtimeDependenciesTable.GetValue(dependencyName).AsTable();
 
-						if (dependencyBuildTable.HasValue("RuntimeDependencies"))
+						if (dependencyTable.HasValue("Build"))
 						{
-							auto runtimeDependencies = dependencyBuildTable
-								.GetValue("RuntimeDependencies")
-								.AsList()
-								.CopyAsStringVector();
-							buildTable.EnsureValue("RuntimeDependencies").EnsureList().Append(runtimeDependencies);
-						}
+							auto dependencyBuildTable = dependencyTable.GetValue("Build").AsTable();
 
-						if (dependencyBuildTable.HasValue("LinkDependencies"))
-						{
-							auto linkDependencies = dependencyBuildTable
-								.GetValue("LinkDependencies")
-								.AsList()
-								.CopyAsStringVector();
-							buildTable.EnsureValue("LinkDependencies").EnsureList().Append(linkDependencies);
+							if (dependencyBuildTable.HasValue("RuntimeDependencies"))
+							{
+								auto runtimeDependencies = dependencyBuildTable
+									.GetValue("RuntimeDependencies")
+									.AsList()
+									.CopyAsStringVector();
+								buildTable.EnsureValue("RuntimeDependencies").EnsureList().Append(runtimeDependencies);
+							}
+
+							if (dependencyBuildTable.HasValue("LinkDependencies"))
+							{
+								auto linkDependencies = dependencyBuildTable
+									.GetValue("LinkDependencies")
+									.AsList()
+									.CopyAsStringVector();
+								buildTable.EnsureValue("LinkDependencies").EnsureList().Append(linkDependencies);
+							}
 						}
 					}
 				}

--- a/Source/Extensions/Cpp/Compiler/Clang.UnitTests/Recipe.toml
+++ b/Source/Extensions/Cpp/Compiler/Clang.UnitTests/Recipe.toml
@@ -2,15 +2,17 @@ Name = "Soup.Cpp.Compiler.Clang.UnitTests"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
-	"../Clang/",
-	"../../../../Build/Runtime/",
-	"Soup.Test.Assert@0.1.7",
-]
 
 Source = [
 	"gen/Main.cpp",
 ]
 IncludePaths = [
 	"./",
+]
+
+[Dependencies]
+Runtime = [
+	"../Clang/",
+	"../../../../Build/Runtime/",
+	"Soup.Test.Assert@0.1.7",
 ]

--- a/Source/Extensions/Cpp/Compiler/Clang/Recipe.toml
+++ b/Source/Extensions/Cpp/Compiler/Clang/Recipe.toml
@@ -1,11 +1,12 @@
 Name = "Soup.Cpp.Compiler.Clang"
 Language = "C++"
 Version = "0.3.0"
-Dependencies = [
+Interface = "Module.cpp"
+
+[Dependencies]
+Runtime = [
 	"../Core/",
 	# "Soup.Build.Compiler@0.3.0",
 	"../MSVC/",
 	# "Soup.Build.Compiler.MSVC@0.3.0",
 ]
-
-Interface = "Module.cpp"

--- a/Source/Extensions/Cpp/Compiler/Core.UnitTests/Recipe.toml
+++ b/Source/Extensions/Cpp/Compiler/Core.UnitTests/Recipe.toml
@@ -2,14 +2,16 @@ Name = "Soup.Cpp.Compiler.Core.UnitTests"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
-	"../Core/",
-	"../../../../Build/Runtime/",
-	"Soup.Test.Assert@0.1.7",
-]
 Source = [
 	"gen/Main.cpp"
 ]
 IncludePaths = [
 	"./",
+]
+
+[Dependencies]
+Runtime = [
+	"../Core/",
+	"../../../../Build/Runtime/",
+	"Soup.Test.Assert@0.1.7",
 ]

--- a/Source/Extensions/Cpp/Compiler/Core/Recipe.toml
+++ b/Source/Extensions/Cpp/Compiler/Core/Recipe.toml
@@ -1,9 +1,10 @@
 Name = "Soup.Cpp.Compiler"
 Language = "C++"
 Version = "0.3.0"
-Dependencies = [
-	"Opal@0.1.8",
-	"Soup.Build.Utilities@0.4.0",
-]
-
 Interface = "Module.cpp"
+
+[Dependencies]
+Runtime = [
+	"Opal@0.1.8",
+	"Soup.Build.Utilities@0.4.1",
+]

--- a/Source/Extensions/Cpp/Compiler/MSVC.UnitTests/Recipe.toml
+++ b/Source/Extensions/Cpp/Compiler/MSVC.UnitTests/Recipe.toml
@@ -2,14 +2,16 @@ Name = "Soup.Cpp.Compiler.MSVC.UnitTests"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
-	"../MSVC/",
-	"../../../../Build/Runtime/",
-	"Soup.Test.Assert@0.1.7",
-]
 Source = [
 	"gen/Main.cpp",
 ]
 IncludePaths = [
 	"./",
+]
+
+[Dependencies]
+Runtime = [
+	"../MSVC/",
+	"../../../../Build/Runtime/",
+	"Soup.Test.Assert@0.1.7",
 ]

--- a/Source/Extensions/Cpp/Compiler/MSVC/Recipe.toml
+++ b/Source/Extensions/Cpp/Compiler/MSVC/Recipe.toml
@@ -1,9 +1,10 @@
 Name = "Soup.Cpp.Compiler.MSVC"
 Language = "C++"
 Version = "0.3.0"
-Dependencies = [
+Interface = "Module.cpp"
+
+[Dependencies]
+Runtime = [
 	"../Core/",
 	# "Soup.Cpp.Compiler@0.3.0",
 ]
-
-Interface = "Module.cpp"

--- a/Source/Extensions/Cpp/Extension.UnitTests/Recipe.toml
+++ b/Source/Extensions/Cpp/Extension.UnitTests/Recipe.toml
@@ -2,15 +2,17 @@ Name = "Soup.Cpp.UnitTests"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
-	"json11@1.0.1",
-	"../../../../Dependencies/SoupTest/Assert/",
-	"../../../Build/Runtime/",
-	"../Extension/",
-]
 Source = [
 	"gen/Main.cpp"
 ]
 IncludePaths = [
 	"./"
+]
+
+[Dependencies]
+Runtime = [
+	"json11@1.0.1",
+	"../../../../Dependencies/SoupTest/Assert/",
+	"../../../Build/Runtime/",
+	"../Extension/",
 ]

--- a/Source/Extensions/Cpp/Extension/Recipe.toml
+++ b/Source/Extensions/Cpp/Extension/Recipe.toml
@@ -2,26 +2,30 @@ Name = "Soup.Cpp"
 Language = "C++"
 Type = "DynamicLibrary"
 Version = "1.0.0"
-Dependencies = [
+Interface = "Module.cpp"
+Source = [
+	"RegisterBuildExtension.cpp",
+]
+
+[Dependencies]
+Runtime = [
 	"Opal@0.1.8",
 	"../../../Build/Runtime/",
 	"../Compiler/Core/",
 	"../Compiler/Clang/",
 	"../Compiler/MSVC/",
 ]
-Interface = "Module.cpp"
-Source = [
-	"RegisterBuildExtension.cpp",
-]
-DevDependencies = [
+Build = [
 	# TODO "../../TestBuild/",
+]
+Test = [
 	"Soup.Test.Assert@0.1.7",
 ]
 
-	[Tests]
-	Source = [
-		"../Extension.UnitTests/gen/Main.cpp"
-	]
-	IncludePaths = [
-		"../Extension.UnitTests/",
-	]
+[Tests]
+Source = [
+	"../Extension.UnitTests/gen/Main.cpp"
+]
+IncludePaths = [
+	"../Extension.UnitTests/",
+]

--- a/Source/Extensions/Cpp/Extension/Tasks/ResolveDependenciesTask.h
+++ b/Source/Extensions/Cpp/Extension/Tasks/ResolveDependenciesTask.h
@@ -79,43 +79,47 @@ namespace Soup::Cpp
 			if (activeState.HasValue("Dependencies"))
 			{
 				auto dependenciesTable = activeState.GetValue("Dependencies").AsTable();
-				auto buildTable = activeState.EnsureValue("Build").EnsureTable();
-
-				for (auto& dependencyName : dependenciesTable.GetValueKeyList().CopyAsStringVector())
+				if (dependenciesTable.HasValue("Runtime"))
 				{
-					// Combine the core dependency build inputs for the core build task
-					buildState.LogInfo("Combine Dependency: " + dependencyName);
-					auto dependencyTable = dependenciesTable.GetValue(dependencyName).AsTable();
+					auto runtimeDependenciesTable = dependenciesTable.GetValue("Runtime").AsTable();
+					auto buildTable = activeState.EnsureValue("Build").EnsureTable();
 
-					if (dependencyTable.HasValue("Build"))
+					for (auto& dependencyName : runtimeDependenciesTable.GetValueKeyList().CopyAsStringVector())
 					{
-						auto dependencyBuildTable = dependencyTable.GetValue("Build").AsTable();
+						// Combine the core dependency build inputs for the core build task
+						buildState.LogInfo("Combine Runtime Dependency: " + dependencyName);
+						auto dependencyTable = runtimeDependenciesTable.GetValue(dependencyName).AsTable();
 
-						if (dependencyBuildTable.HasValue("ModuleDependencies"))
+						if (dependencyTable.HasValue("Build"))
 						{
-							auto moduleDependencies = dependencyBuildTable
-								.GetValue("ModuleDependencies")
-								.AsList()
-								.CopyAsStringVector();
-							buildTable.EnsureValue("ModuleDependencies").EnsureList().Append(moduleDependencies);
-						}
+							auto dependencyBuildTable = dependencyTable.GetValue("Build").AsTable();
 
-						if (dependencyBuildTable.HasValue("RuntimeDependencies"))
-						{
-							auto runtimeDependencies = dependencyBuildTable
-								.GetValue("RuntimeDependencies")
-								.AsList()
-								.CopyAsStringVector();
-							buildTable.EnsureValue("RuntimeDependencies").EnsureList().Append(runtimeDependencies);
-						}
+							if (dependencyBuildTable.HasValue("ModuleDependencies"))
+							{
+								auto moduleDependencies = dependencyBuildTable
+									.GetValue("ModuleDependencies")
+									.AsList()
+									.CopyAsStringVector();
+								buildTable.EnsureValue("ModuleDependencies").EnsureList().Append(moduleDependencies);
+							}
 
-						if (dependencyBuildTable.HasValue("LinkDependencies"))
-						{
-							auto linkDependencies = dependencyBuildTable
-								.GetValue("LinkDependencies")
-								.AsList()
-								.CopyAsStringVector();
-							buildTable.EnsureValue("LinkDependencies").EnsureList().Append(linkDependencies);
+							if (dependencyBuildTable.HasValue("RuntimeDependencies"))
+							{
+								auto runtimeDependencies = dependencyBuildTable
+									.GetValue("RuntimeDependencies")
+									.AsList()
+									.CopyAsStringVector();
+								buildTable.EnsureValue("RuntimeDependencies").EnsureList().Append(runtimeDependencies);
+							}
+
+							if (dependencyBuildTable.HasValue("LinkDependencies"))
+							{
+								auto linkDependencies = dependencyBuildTable
+									.GetValue("LinkDependencies")
+									.AsList()
+									.CopyAsStringVector();
+								buildTable.EnsureValue("LinkDependencies").EnsureList().Append(linkDependencies);
+							}
 						}
 					}
 				}

--- a/Source/Extensions/TestBuild/Recipe.toml
+++ b/Source/Extensions/TestBuild/Recipe.toml
@@ -2,7 +2,12 @@ Name = "Soup.Test"
 Language = "C++"
 Type = "DynamicLibrary"
 Version = "0.1.1"
-Dependencies = [
+Source = [
+	"RegisterBuildExtension.cpp",
+]
+
+[Dependencies]
+Runtime = [
 	"Opal@0.1.8",
 	"../Cpp/Compiler/Core/",
 	# "Soup.Build.Compiler@0.3.0",
@@ -10,7 +15,4 @@ Dependencies = [
 	# "Soup.Build.Compiler.Clang@0.3.0",
 	"../Cpp/Compiler/MSVC/",
 	# "Soup.Build.Compiler.MSVC@0.3.0",
-]
-Source = [
-	"RegisterBuildExtension.cpp",
 ]

--- a/Source/Installer/SoupInstaller/Setup.cs
+++ b/Source/Installer/SoupInstaller/Setup.cs
@@ -5,7 +5,7 @@ class Script
 {
 	static public void Main()
 	{
-		var soupBinFolder = @"..\..\Client\CLI\out\MSVC\release\win32\x64\bin\";
+		var soupBinFolder = @"..\..\..\out\Soup\MSVC\release\win32\x64\bin\";
 		var project = new Project(
 			"Soup",
 			new Dir(
@@ -42,7 +42,7 @@ class Script
 		};
 
 		// Upgrade values
-		project.Version = new Version(0, 9, 6);
+		project.Version = new Version(0, 10, 0);
 
 		Compiler.BuildMsi(project);
 	}

--- a/Source/Monitor/Detours/Recipe.toml
+++ b/Source/Monitor/Detours/Recipe.toml
@@ -2,14 +2,16 @@ Name = "Monitor.Detours"
 Language = "C++"
 Version = "1.0.0"
 Type = "DynamicLibrary"
-Dependencies = [
-	"../../../Dependencies/Detours/src/",
-	"../Shared/",
-]
 Defines = [
 	# "ENABLE_MONITOR_DEBUG",
 	# "TRACE_DETOUR_CLIENT",
 ]
 Source = [
 	"Main.cpp",
+]
+
+[Dependencies]
+Runtime = [
+	"../../../Dependencies/Detours/src/",
+	"../Shared/",
 ]

--- a/Source/Monitor/Log/Recipe.toml
+++ b/Source/Monitor/Log/Recipe.toml
@@ -3,11 +3,13 @@ Name = "LogMonitor"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
+Source = [
+	"Main.cpp",
+]
+
+[Dependencies]
+Runtime = [
 	"../../../Dependencies/Detours/src/",
 	"Opal@0.1.8",
 	"../Shared/",
-]
-Source = [
-	"Main.cpp",
 ]

--- a/Source/Monitor/Shared/Recipe.toml
+++ b/Source/Monitor/Shared/Recipe.toml
@@ -1,11 +1,13 @@
 Name = "Monitor.Shared"
 Language = "C++"
 Version = "1.0.0"
-Dependencies = [
-	"../../../Dependencies/Detours/src/",
-	"Opal@0.1.8",
-]
 Defines = [
 	# "TRACE_DETOUR_SERVER",
 ]
 Interface = "Module.cpp"
+
+[Dependencies]
+Runtime = [
+	"../../../Dependencies/Detours/src/",
+	"Opal@0.1.8",
+]

--- a/Source/Tools/PrintGraph/Recipe.toml
+++ b/Source/Tools/PrintGraph/Recipe.toml
@@ -2,10 +2,12 @@ Name = "printgraph"
 Language = "C++"
 Version = "1.0.0"
 Type = "Executable"
-Dependencies = [
-	"Opal@0.1.8",
-	"../../Build/Runtime/"
-]
 Source = [
 	"Main.cpp",
+]
+
+[Dependencies]
+Runtime = [
+	"Opal@0.1.8",
+	"../../Build/Runtime/"
 ]


### PR DESCRIPTION
With this change I am moving the Runtime/Build/Test dependency lists into a root Dependencies table so the tests and build dependencies can be broken out so the builds can be run on a different architecture/flavor.