### PR TITLE
Cleanup Relative Paths

### DIFF
--- a/Source/Client/CLI/Recipe.toml
+++ b/Source/Client/CLI/Recipe.toml
@@ -1,6 +1,6 @@
 Name = "Soup"
 Language = "C++"
-Version = "0.15.0"
+Version = "0.15.1"
 Type = "Executable"
 
 Source = [

--- a/Source/Client/CLI/Source/Commands/TargetCommand.h
+++ b/Source/Client/CLI/Source/Commands/TargetCommand.h
@@ -91,7 +91,7 @@ namespace Soup::Client
 				isHostBuild,
 				buildManager);
 			
-			Log::HighPriority(targetDirectory.ToString());
+			std::cout << targetDirectory.ToString() << std::flush;
 		}
 
 	private:

--- a/Source/Client/CLI/Source/Commands/VersionCommand.h
+++ b/Source/Client/CLI/Source/Commands/VersionCommand.h
@@ -31,7 +31,7 @@ namespace Soup::Client
 
 			// TODO var version = Assembly.GetExecutingAssembly().GetName().Version;
 			// Log::Message($"{version.Major}.{version.Minor}.{version.Build}");
-			Log::HighPriority("0.15.0");
+			Log::HighPriority("0.15.1");
 		}
 
 	private:

--- a/Source/Client/Core/Recipe.toml
+++ b/Source/Client/Core/Recipe.toml
@@ -16,7 +16,7 @@ Runtime = [
 	"../../Build/Runtime/",
 ]
 Build = [
-	"Soup.Test.Cpp@0.1.1",
+	# TODO: "Soup.Test.Cpp@0.1.1",
 ]
 Test = [
 	"Soup.Test.Assert@0.1.8",

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
@@ -180,7 +180,7 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 				Assert.Equal(
 					new List<Path>()
 					{
-						new Path("./bin/Program.mock.dll"),
+						new Path("C:/target/bin/Program.mock.dll"),
 					},
 					result.RuntimeDependencies);
 			}
@@ -331,19 +331,19 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 				Assert.Equal(
 					new List<Path>()
 					{
-						new Path("bin/ref/Library.mock.dll"),
+						new Path("C:/target/bin/ref/Library.mock.dll"),
 					},
 					result.LinkDependencies);
 
 				Assert.Equal(
 					new List<Path>()
 					{
-						new Path("bin/Library.mock.dll"),
+						new Path("C:/target/bin/Library.mock.dll"),
 					},
 					result.RuntimeDependencies);
 
 				Assert.Equal(
-					new Path("bin/Library.mock.dll"),
+					new Path("C:/target/bin/Library.mock.dll"),
 					result.TargetFile);
 			}
 		}

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
@@ -34,7 +34,8 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 				var arguments = new BuildArguments();
 				arguments.TargetName = "Program";
 				arguments.TargetType = BuildTargetType.Executable;
-				arguments.WorkingDirectory = new Path("C:/root/");
+				arguments.SourceRootDirectory = new Path("C:/source/");
+				arguments.TargetRootDirectory = new Path("C:/target/");
 				arguments.ObjectDirectory = new Path("obj/");
 				arguments.BinaryDirectory = new Path("bin/");
 				arguments.SourceFiles = new List<Path>()
@@ -78,7 +79,8 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 					ReferenceTarget = new Path("./bin/ref/Program.mock.dll"),
 					TargetType = LinkTarget.Executable,
 					ObjectDirectory = new Path("obj/"),
-					RootDirectory = new Path("C:/root/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
 					SourceFiles = new List<Path>()
 					{
 						new Path("TestFile.cs"),
@@ -106,7 +108,7 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 				{
 					new BuildOperation(
 						"MakeDir [./obj/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./obj/\"",
 						new List<Path>(),
@@ -116,7 +118,7 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/\"",
 						new List<Path>(),
@@ -126,7 +128,7 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/ref/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/ref/\"",
 						new List<Path>(),
@@ -149,7 +151,7 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 						}),
 					new BuildOperation(
 						"WriteFile [./bin/Program.runtimeconfig.json]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("./writefile.exe"),
 						@"""./bin/Program.runtimeconfig.json"" ""{
   ""runtimeOptions"": {
@@ -202,7 +204,8 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 				var arguments = new BuildArguments();
 				arguments.TargetName = "Library";
 				arguments.TargetType = BuildTargetType.Library;
-				arguments.WorkingDirectory = new Path("C:/root/");
+				arguments.SourceRootDirectory = new Path("C:/source/");
+				arguments.TargetRootDirectory = new Path("C:/target/");
 				arguments.ObjectDirectory = new Path("obj/");
 				arguments.BinaryDirectory = new Path("bin/");
 				arguments.SourceFiles = new List<Path>()
@@ -248,7 +251,8 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 				{
 					Target = new Path("./bin/Library.mock.dll"),
 					ReferenceTarget = new Path("./bin/ref/Library.mock.dll"),
-					RootDirectory = new Path("C:/root/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
 					ObjectDirectory = new Path("obj/"),
 					SourceFiles = new List<Path>()
 					{
@@ -277,7 +281,7 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 				{
 					new BuildOperation(
 						"MakeDir [./obj/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./obj/\"",
 						new List<Path>(),
@@ -287,7 +291,7 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/\"",
 						new List<Path>(),
@@ -297,7 +301,7 @@ namespace Soup.Build.CSharp.Compiler.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/ref/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/ref/\"",
 						new List<Path>(),

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Core/BuildArguments.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Core/BuildArguments.cs
@@ -96,9 +96,14 @@ namespace Soup.Build.CSharp.Compiler
 		public BuildTargetType TargetType { get; set; }
 
 		/// <summary>
-		/// Gets or sets the working directory
+		/// Gets or sets the source directory
 		/// </summary>
-		public Path WorkingDirectory { get; set; } = new Path();
+		public Path SourceRootDirectory { get; set; } = new Path();
+
+		/// <summary>
+		/// Gets or sets the target directory
+		/// </summary>
+		public Path TargetRootDirectory { get; set; } = new Path();
 
 		/// <summary>
 		/// Gets or sets the output object directory

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Core/BuildEngine.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Core/BuildEngine.cs
@@ -79,10 +79,10 @@ namespace Soup.Build.CSharp.Compiler
 							new Path(arguments.TargetName + "." + _compiler.DynamicLibraryFileExtension);
 
 						// Add the DLL as a runtime dependency
-						result.RuntimeDependencies.Add(targetFile);
+						result.RuntimeDependencies.Add(arguments.TargetRootDirectory + targetFile);
 
 						// Link against the reference target
-						result.LinkDependencies.Add(referenceTargetFile);
+						result.LinkDependencies.Add(arguments.TargetRootDirectory + referenceTargetFile);
 
 						break;
 					case BuildTargetType.Executable:
@@ -95,7 +95,7 @@ namespace Soup.Build.CSharp.Compiler
 							new Path(arguments.TargetName + "." + _compiler.DynamicLibraryFileExtension);
 
 						// Add the Executable as a runtime dependency
-						result.RuntimeDependencies.Add(targetFile);
+						result.RuntimeDependencies.Add(arguments.TargetRootDirectory + targetFile);
 
 						// All link dependencies stop here.
 
@@ -110,10 +110,10 @@ namespace Soup.Build.CSharp.Compiler
 							new Path(arguments.TargetName + "." + _compiler.ModuleFileExtension);
 
 						// Add the DLL as a runtime dependency
-						result.RuntimeDependencies.Add(targetFile);
+						result.RuntimeDependencies.Add(arguments.TargetRootDirectory + targetFile);
 
 						// Link against the reference target
-						result.LinkDependencies.Add(referenceTargetFile);
+						result.LinkDependencies.Add(arguments.TargetRootDirectory + referenceTargetFile);
 
 						break;
 					default:
@@ -165,7 +165,7 @@ namespace Soup.Build.CSharp.Compiler
 				foreach (var operation in compileOperations)
 					result.BuildOperations.Add(operation);
 
-				result.TargetFile = targetFile;
+				result.TargetFile = arguments.TargetRootDirectory + targetFile;
 			}
 		}
 

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Core/BuildEngine.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Core/BuildEngine.cs
@@ -30,15 +30,15 @@ namespace Soup.Build.CSharp.Compiler
 			var referenceDirectory = arguments.BinaryDirectory + new Path("ref/");
 			result.BuildOperations.Add(
 				SharedOperations.CreateCreateDirectoryOperation(
-					arguments.WorkingDirectory,
+					arguments.TargetRootDirectory,
 					arguments.ObjectDirectory));
 			result.BuildOperations.Add(
 				SharedOperations.CreateCreateDirectoryOperation(
-					arguments.WorkingDirectory,
+					arguments.TargetRootDirectory,
 					arguments.BinaryDirectory));
 			result.BuildOperations.Add(
 				SharedOperations.CreateCreateDirectoryOperation(
-					arguments.WorkingDirectory,
+					arguments.TargetRootDirectory,
 					referenceDirectory));
 
 			// Perform the core compilation of the source files
@@ -146,7 +146,8 @@ namespace Soup.Build.CSharp.Compiler
 					Target = targetFile,
 					ReferenceTarget = referenceTargetFile,
 					TargetType = targetType,
-					RootDirectory = arguments.WorkingDirectory,
+					SourceRootDirectory = arguments.SourceRootDirectory,
+					TargetRootDirectory = arguments.TargetRootDirectory,
 					ObjectDirectory = arguments.ObjectDirectory,
 					SourceFiles = arguments.SourceFiles,
 					PreprocessorDefinitions = arguments.PreprocessorDefinitions,
@@ -182,7 +183,7 @@ namespace Soup.Build.CSharp.Compiler
 				{
 					var target = arguments.BinaryDirectory + new Path(source.GetFileName());
 					var operation = SharedOperations.CreateCopyFileOperation(
-						arguments.WorkingDirectory,
+						arguments.TargetRootDirectory,
 						source,
 						target);
 					result.BuildOperations.Add(operation);
@@ -212,7 +213,7 @@ namespace Soup.Build.CSharp.Compiler
   }
 }";
 				var writeRuntimeConfigFile = SharedOperations.CreateWriteFileOperation(
-					arguments.WorkingDirectory,
+					arguments.TargetRootDirectory,
 					runtimeConfigFile,
 					content);
 				result.BuildOperations.Add(writeRuntimeConfigFile);

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Core/CompileArguments.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Core/CompileArguments.cs
@@ -62,9 +62,14 @@ namespace Soup.Build.CSharp.Compiler
 	public class CompileArguments : IEquatable<CompileArguments>
 	{
 		/// <summary>
-		/// Gets or sets the root directory
+		/// Gets or sets the source directory
 		/// </summary>
-		public Path RootDirectory { get; init; } = new Path();
+		public Path SourceRootDirectory { get; init; } = new Path();
+
+		/// <summary>
+		/// Gets or sets the target directory
+		/// </summary>
+		public Path TargetRootDirectory { get; init; } = new Path();
 
 		/// <summary>
 		/// Gets or sets the object directory
@@ -148,7 +153,8 @@ namespace Soup.Build.CSharp.Compiler
 				return true;
 
 			// Return true if the fields match.
-			return this.RootDirectory == rhs.RootDirectory &&
+			return this.SourceRootDirectory == rhs.SourceRootDirectory &&
+				this.TargetRootDirectory == rhs.TargetRootDirectory &&
 				this.ObjectDirectory == rhs.ObjectDirectory &&
 				Enumerable.SequenceEqual(this.PreprocessorDefinitions, rhs.PreprocessorDefinitions) &&
 				Enumerable.SequenceEqual(this.ReferenceLibraries, rhs.ReferenceLibraries) &&
@@ -165,7 +171,7 @@ namespace Soup.Build.CSharp.Compiler
 				Enumerable.SequenceEqual(this.CustomProperties, rhs.CustomProperties);
 		}
 
-		public override int GetHashCode() => (RootDirectory, ObjectDirectory, Target).GetHashCode();
+		public override int GetHashCode() => (SourceRootDirectory, TargetRootDirectory, ObjectDirectory, Target).GetHashCode();
 
 		public static bool operator ==(CompileArguments? lhs, CompileArguments? rhs)
 		{
@@ -184,7 +190,7 @@ namespace Soup.Build.CSharp.Compiler
 
 		public override string ToString()
 		{
-			return $"SharedCompileArguments {{ RootDirectory=\"{RootDirectory}\", ObjectDirectory=\"{ObjectDirectory}\", PreprocessorDefinitions=[{string.Join(",", PreprocessorDefinitions)}], ReferenceLibraries=[{string.Join(",", ReferenceLibraries)}], SourceFiles=[{string.Join(",", SourceFiles)}], EnableOptimizations=\"{EnableOptimizations}\", GenerateSourceDebugInfo=\"{GenerateSourceDebugInfo}\", TargetType={TargetType}, Target={Target}, ReferenceTarget={ReferenceTarget}, EnableWarningsAsErrors=\"{EnableWarningsAsErrors}\", DisabledWarnings=[{string.Join(",", DisabledWarnings)}], EnabledWarnings=[{string.Join(",", EnabledWarnings)}], NullableState=\"{NullableState}\" CustomProperties=[{string.Join(",", CustomProperties)}]}}";
+			return $"SharedCompileArguments {{ SourceRootDirectory=\"{SourceRootDirectory}\", TargetRootDirectory=\"{TargetRootDirectory}\", ObjectDirectory=\"{ObjectDirectory}\", PreprocessorDefinitions=[{string.Join(",", PreprocessorDefinitions)}], ReferenceLibraries=[{string.Join(",", ReferenceLibraries)}], SourceFiles=[{string.Join(",", SourceFiles)}], EnableOptimizations=\"{EnableOptimizations}\", GenerateSourceDebugInfo=\"{GenerateSourceDebugInfo}\", TargetType={TargetType}, Target={Target}, ReferenceTarget={ReferenceTarget}, EnableWarningsAsErrors=\"{EnableWarningsAsErrors}\", DisabledWarnings=[{string.Join(",", DisabledWarnings)}], EnabledWarnings=[{string.Join(",", EnabledWarnings)}], NullableState=\"{NullableState}\" CustomProperties=[{string.Join(",", CustomProperties)}]}}";
 		}
 	}
 }

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Roslyn.UnitTests/CompilerUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Roslyn.UnitTests/CompilerUnitTests.cs
@@ -31,7 +31,8 @@ namespace Soup.Build.CSharp.Compiler.Roslyn.UnitTests
 			{
 				Target = new Path("bin/Target.dll"),
 				ReferenceTarget = new Path("ref/Target.dll"),
-				RootDirectory = new Path("Source/"),
+				SourceRootDirectory = new Path("C:/source/"),
+				TargetRootDirectory = new Path("C:/target/"),
 				ObjectDirectory = new Path("ObjectDir/"),
 				SourceFiles = new List<Path>()
 				{
@@ -46,7 +47,7 @@ namespace Soup.Build.CSharp.Compiler.Roslyn.UnitTests
 			{
 				new BuildOperation(
 					"WriteFile [./ObjectDir/CompileArguments.rsp]",
-					new Path("Source/"),
+					new Path("C:/target/"),
 					new Path("./writefile.exe"),
 					"\"./ObjectDir/CompileArguments.rsp\" \"/unsafe- /checked- /fullpaths /nostdlib+ /errorreport:prompt /warn:5 /errorendlocation /preferreduilang:en-US /highentropyva+ /nullable:enable /debug+ /debug:portable /filealign:512 /optimize- /out:\"./bin/Target.dll\" /refout:\"./ref/Target.dll\" /target:library /warnaserror- /utf8output /deterministic+ /langversion:9.0 \"./File.cs\"\"",
 					new List<Path>(),
@@ -56,7 +57,7 @@ namespace Soup.Build.CSharp.Compiler.Roslyn.UnitTests
 					}),
 				new BuildOperation(
 					"Compile - ./bin/Target.dll",
-					new Path("Source/"),
+					new Path("C:/source/"),
 					new Path("C:/bin/mock.csc.exe"),
 					"@./ObjectDir/CompileArguments.rsp /noconfig",
 					new List<Path>()

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Roslyn.UnitTests/CompilerUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Roslyn.UnitTests/CompilerUnitTests.cs
@@ -49,7 +49,7 @@ namespace Soup.Build.CSharp.Compiler.Roslyn.UnitTests
 					"WriteFile [./ObjectDir/CompileArguments.rsp]",
 					new Path("C:/target/"),
 					new Path("./writefile.exe"),
-					"\"./ObjectDir/CompileArguments.rsp\" \"/unsafe- /checked- /fullpaths /nostdlib+ /errorreport:prompt /warn:5 /errorendlocation /preferreduilang:en-US /highentropyva+ /nullable:enable /debug+ /debug:portable /filealign:512 /optimize- /out:\"./bin/Target.dll\" /refout:\"./ref/Target.dll\" /target:library /warnaserror- /utf8output /deterministic+ /langversion:9.0 \"./File.cs\"\"",
+					"\"./ObjectDir/CompileArguments.rsp\" \"/unsafe- /checked- /fullpaths /nostdlib+ /errorreport:prompt /warn:5 /errorendlocation /preferreduilang:en-US /highentropyva+ /nullable:enable /debug+ /debug:portable /filealign:512 /optimize- /out:\"C:/target/bin/Target.dll\" /refout:\"C:/target/ref/Target.dll\" /target:library /warnaserror- /utf8output /deterministic+ /langversion:9.0 \"./File.cs\"\"",
 					new List<Path>(),
 					new List<Path>()
 					{
@@ -59,17 +59,17 @@ namespace Soup.Build.CSharp.Compiler.Roslyn.UnitTests
 					"Compile - ./bin/Target.dll",
 					new Path("C:/source/"),
 					new Path("C:/bin/mock.csc.exe"),
-					"@./ObjectDir/CompileArguments.rsp /noconfig",
+					"@C:/target/ObjectDir/CompileArguments.rsp /noconfig",
 					new List<Path>()
 					{
-						new Path("./ObjectDir/CompileArguments.rsp"),
-						new Path("File.cs"),
+						new Path("C:/target/ObjectDir/CompileArguments.rsp"),
+						new Path("./File.cs"),
 					},
 					new List<Path>()
 					{
-						new Path("./bin/Target.dll"),
-						new Path("./ref/Target.dll"),
-						new Path("./bin/Target.pdb"),
+						new Path("C:/target/bin/Target.dll"),
+						new Path("C:/target/ref/Target.dll"),
+						new Path("C:/target/bin/Target.pdb"),
 					}),
 				};
 

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Roslyn/ArgumentBuilder.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Roslyn/ArgumentBuilder.cs
@@ -100,13 +100,15 @@ namespace Soup.Build.CSharp.Compiler.Roslyn
 				AddFlag(commandArguments, "optimize-");
 
 			// Specify output file name
-			AddParameterWithQuotes(commandArguments, "out", arguments.Target.ToString());
+			var absoluteTarget = arguments.TargetRootDirectory + arguments.Target;
+			AddParameterWithQuotes(commandArguments, "out", absoluteTarget.ToString());
 
 			// Reference assembly output to generate
 			// Note: Modules cannot use refout
 			if (arguments.TargetType != LinkTarget.Module)
 			{
-				AddParameterWithQuotes(commandArguments, "refout", arguments.ReferenceTarget.ToString());
+				var absoluteReferenceTarget = arguments.TargetRootDirectory + arguments.ReferenceTarget;
+				AddParameterWithQuotes(commandArguments, "refout", absoluteReferenceTarget.ToString());
 			}
 
 			switch (arguments.TargetType)

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Roslyn/Compiler.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Roslyn/Compiler.cs
@@ -65,21 +65,23 @@ namespace Soup.Build.CSharp.Compiler.Roslyn
 			var symbolFile = new Path(arguments.Target.ToString());
 			symbolFile.SetFileExtension("pdb");
 
+			var targetResponseFile = arguments.TargetRootDirectory + responseFile;
+
 			// Build up the input/output sets
 			var inputFiles = new List<Path>();
-			inputFiles.Add(responseFile);
+			inputFiles.Add(targetResponseFile);
 			inputFiles.AddRange(arguments.SourceFiles);
 			inputFiles.AddRange(arguments.ReferenceLibraries);
 			var outputFiles = new List<Path>()
 			{
-				arguments.Target,
-				arguments.ReferenceTarget,
-				symbolFile,
+				arguments.TargetRootDirectory + arguments.Target,
+				arguments.TargetRootDirectory + arguments.ReferenceTarget,
+				arguments.TargetRootDirectory + symbolFile,
 			};
 
 			// Generate the compile build operation
 			var uniqueCommandArguments = ArgumentBuilder.BuildUniqueCompilerArguments();
-			var commandArguments = $"@{responseFile} {string.Join(" ", uniqueCommandArguments)}";
+			var commandArguments = $"@{targetResponseFile} {string.Join(" ", uniqueCommandArguments)}";
 			var buildOperation = new BuildOperation(
 				$"Compile - {arguments.Target}",
 				arguments.SourceRootDirectory,

--- a/Source/GenerateSharp/Extensions/CSharp/Compiler/Roslyn/Compiler.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Compiler/Roslyn/Compiler.cs
@@ -57,7 +57,7 @@ namespace Soup.Build.CSharp.Compiler.Roslyn
 			var responseFile = arguments.ObjectDirectory + new Path("CompileArguments.rsp");
 			var sharedCommandArguments = ArgumentBuilder.BuildSharedCompilerArguments(arguments);
 			var writeSharedArgumentsOperation = SharedOperations.CreateWriteFileOperation(
-				arguments.RootDirectory,
+				arguments.TargetRootDirectory,
 				responseFile,
 				string.Join(" ", sharedCommandArguments));
 			operations.Add(writeSharedArgumentsOperation);
@@ -82,7 +82,7 @@ namespace Soup.Build.CSharp.Compiler.Roslyn
 			var commandArguments = $"@{responseFile} {string.Join(" ", uniqueCommandArguments)}";
 			var buildOperation = new BuildOperation(
 				$"Compile - {arguments.Target}",
-				arguments.RootDirectory,
+				arguments.SourceRootDirectory,
 				_compilerExecutable,
 				commandArguments,
 				inputFiles,

--- a/Source/GenerateSharp/Extensions/CSharp/Extension.UnitTests/Tasks/BuildTaskUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Extension.UnitTests/Tasks/BuildTaskUnitTests.cs
@@ -49,7 +49,8 @@ namespace Soup.Build.CSharp.UnitTests
 				state.Add("Build", new Value(buildTable));
 				buildTable.Add("TargetName", new Value("Program"));
 				buildTable.Add("TargetType", new Value((long)BuildTargetType.Executable));
-				buildTable.Add("WorkingDirectory", new Value("C:/root/"));
+				buildTable.Add("SourceRootDirectory", new Value("C:/source/"));
+				buildTable.Add("TargetRootDirectory", new Value("C:/target/"));
 				buildTable.Add("ObjectDirectory", new Value("obj/"));
 				buildTable.Add("BinaryDirectory", new Value("bin/"));
 				buildTable.Add(
@@ -98,7 +99,8 @@ namespace Soup.Build.CSharp.UnitTests
 					Target = new Path("./bin/Program.mock.dll"),
 					ReferenceTarget = new Path("./bin/ref/Program.mock.dll"),
 					TargetType = LinkTarget.Executable,
-					RootDirectory = new Path("C:/root/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
 					ObjectDirectory = new Path("obj/"),
 					SourceFiles = new List<Path>()
 					{
@@ -119,7 +121,7 @@ namespace Soup.Build.CSharp.UnitTests
 				{
 					new BuildOperation(
 						"MakeDir [./obj/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./obj/\"",
 						new List<Path>(),
@@ -129,7 +131,7 @@ namespace Soup.Build.CSharp.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/\"",
 						new List<Path>(),
@@ -139,7 +141,7 @@ namespace Soup.Build.CSharp.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/ref/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/ref/\"",
 						new List<Path>(),
@@ -162,7 +164,7 @@ namespace Soup.Build.CSharp.UnitTests
 						}),
 					new BuildOperation(
 						"WriteFile [./bin/Program.runtimeconfig.json]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("./writefile.exe"),
 						@"""./bin/Program.runtimeconfig.json"" ""{
   ""runtimeOptions"": {
@@ -206,7 +208,8 @@ namespace Soup.Build.CSharp.UnitTests
 				state.Add("Build", new Value(buildTable));
 				buildTable.Add("TargetName", new Value("Library"));
 				buildTable.Add("TargetType", new Value((long)BuildTargetType.Library));
-				buildTable.Add("WorkingDirectory", new Value("C:/root/"));
+				buildTable.Add("SourceRootDirectory", new Value("C:/source/"));
+				buildTable.Add("TargetRootDirectory", new Value("C:/target/"));
 				buildTable.Add("ObjectDirectory", new Value("obj/"));
 				buildTable.Add("BinaryDirectory", new Value("bin/"));
 				buildTable.Add("Source", new Value(new ValueList()
@@ -266,7 +269,8 @@ namespace Soup.Build.CSharp.UnitTests
 				{
 					Target = new Path("./bin/Library.mock.dll"),
 					ReferenceTarget = new Path("./bin/ref/Library.mock.dll"),
-					RootDirectory = new Path("C:/root/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
 					ObjectDirectory = new Path("obj/"),
 					SourceFiles = new List<Path>()
 					{
@@ -289,7 +293,7 @@ namespace Soup.Build.CSharp.UnitTests
 				{
 					new BuildOperation(
 						"MakeDir [./obj/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./obj/\"",
 						new List<Path>(),
@@ -299,7 +303,7 @@ namespace Soup.Build.CSharp.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/\"",
 						new List<Path>(),
@@ -309,7 +313,7 @@ namespace Soup.Build.CSharp.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/ref/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/ref/\"",
 						new List<Path>(),

--- a/Source/GenerateSharp/Extensions/CSharp/Extension/Tasks/BuildTask.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Extension/Tasks/BuildTask.cs
@@ -65,9 +65,9 @@ namespace Soup.Build.CSharp
 			var arguments = new BuildArguments();
 			arguments.TargetArchitecture = parametersTable["Architecture"].AsString();
 			arguments.TargetName = buildTable["TargetName"].AsString();
-			arguments.TargetType = (BuildTargetType)
-				buildTable["TargetType"].AsInteger();
-			arguments.WorkingDirectory = new Path(buildTable["WorkingDirectory"].AsString());
+			arguments.TargetType = (BuildTargetType)buildTable["TargetType"].AsInteger();
+			arguments.SourceRootDirectory = new Path(buildTable["SourceRootDirectory"].AsString());
+			arguments.TargetRootDirectory = new Path(buildTable["TargetRootDirectory"].AsString());
 			arguments.ObjectDirectory = new Path(buildTable["ObjectDirectory"].AsString());
 			arguments.BinaryDirectory = new Path(buildTable["BinaryDirectory"].AsString());
 

--- a/Source/GenerateSharp/Extensions/CSharp/Extension/Tasks/RecipeBuildTask.cs
+++ b/Source/GenerateSharp/Extensions/CSharp/Extension/Tasks/RecipeBuildTask.cs
@@ -115,8 +115,8 @@ namespace Soup.Build.CSharp
 
 			// Build up arguments to build this individual recipe
 			var targetDirectory = new Path(parametersTable["TargetDirectory"].AsString());
-			var binaryDirectory = targetDirectory + new Path("bin/");
-			var objectDirectory = targetDirectory + new Path("obj/");
+			var binaryDirectory = new Path("bin/");
+			var objectDirectory = new Path("obj/");
 
 			// Load the source files if present
 			var sourceFiles = new List<string>();
@@ -165,7 +165,8 @@ namespace Soup.Build.CSharp
 			}
 
 			buildTable["TargetName"] = this.factory.Create(name);
-			buildTable["WorkingDirectory"] = this.factory.Create(packageRoot.ToString());
+            buildTable["SourceRootDirectory"] = this.factory.Create(packageRoot.ToString());
+            buildTable["TargetRootDirectory"] = this.factory.Create(targetDirectory.ToString());
 			buildTable["ObjectDirectory"] = this.factory.Create(objectDirectory.ToString());
 			buildTable["BinaryDirectory"] = this.factory.Create(binaryDirectory.ToString());
 			buildTable["OptimizationLevel"] = this.factory.Create((long)optimizationLevel);

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
@@ -7,945 +7,951 @@ using Xunit;
 
 namespace Soup.Build.Cpp.Compiler.UnitTests
 {
-	public class BuildEngineUnitTests
-	{
-		[Fact]
-		public void Initialize_Success()
-		{
-			var compiler = new Mock.Compiler();
-			var uut = new BuildEngine(compiler);
-		}
-
-		[Fact]
-		public void Build_Executable()
-		{
-			// Register the test process manager
-			var processManager = new MockProcessManager();
-
-			// Register the test listener
-			var testListener = new TestTraceListener();
-			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
-			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
-			{
-
-				// Register the mock compiler
-				var compiler = new Mock.Compiler();
-
-				// Register the test process manager
-
-				// Setup the build arguments
-				var arguments = new BuildArguments();
-				arguments.TargetName = "Program";
-				arguments.TargetType = BuildTargetType.Executable;
-				arguments.LanguageStandard = LanguageStandard.CPP20;
-				arguments.WorkingDirectory = new Path("C:/root/");
-				arguments.ObjectDirectory = new Path("obj/");
-				arguments.BinaryDirectory = new Path("bin/");
-				arguments.SourceFiles = new List<Path>()
-				{
-					new Path("TestFile.cpp"),
-				};
-				arguments.OptimizationLevel = BuildOptimizationLevel.None;
-				arguments.LinkDependencies = new List<Path>()
-				{
-					new Path("../Other/bin/OtherModule1.mock.a"),
-					new Path("../OtherModule2.mock.a"),
-				};
-
-				var uut = new BuildEngine(compiler);
-				var fileSystemState = new FileSystemState();
-				var readAccessList = new List<Path>();
-				var writeAccessList = new List<Path>();
-				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
-				var result = uut.Execute(buildState, arguments);
-
-				// Verify expected process manager requests
-				Assert.Equal(
-					new List<string>()
-					{
-						"GetCurrentProcessFileName",
-						"GetCurrentProcessFileName",
-					},
-					processManager.GetRequests());
-
-				// Verify expected logs
-				Assert.Equal(
-					new List<string>()
-					{
-						"INFO: Generate Compile Operation: ./TestFile.cpp",
-						"INFO: CoreLink",
-						"INFO: Linking target",
-						"INFO: Generate Link Operation: ./bin/Program.exe",
-					},
-					testListener.GetMessages());
-
-				var expectedCompileArguments = new SharedCompileArguments()
-				{
-					Standard = LanguageStandard.CPP20,
-					Optimize = OptimizationLevel.None,
-					ObjectDirectory = new Path("obj/"),
-					RootDirectory = new Path("C:/root/"),
-				};
-
-				var expectedTranslationUnitArguments = new TranslationUnitCompileArguments();
-				expectedTranslationUnitArguments.SourceFile = new Path("TestFile.cpp");
-				expectedTranslationUnitArguments.TargetFile = new Path("obj/TestFile.mock.obj");
-				expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
-				{
-					expectedTranslationUnitArguments,
-				};
-
-				var expectedLinkArguments = new LinkArguments();
-				expectedLinkArguments.TargetType = LinkTarget.Executable;
-				expectedLinkArguments.TargetFile = new Path("bin/Program.exe");
-				expectedLinkArguments.RootDirectory = new Path("C:/root/");
-				expectedLinkArguments.ObjectFiles = new List<Path>()
-				{
-					new Path("obj/TestFile.mock.obj"),
-				};
-				expectedLinkArguments.LibraryFiles = new List<Path>()
-				{
-					new Path("../Other/bin/OtherModule1.mock.a"),
-					new Path("../OtherModule2.mock.a"),
-				};
-
-				// Verify expected compiler calls
-				var val = compiler.GetCompileRequests()[0];
-				var areEqual = val == expectedCompileArguments;
-				var areEqual2 = val.ObjectDirectory == expectedCompileArguments.ObjectDirectory;
-				Assert.Equal(
-					new List<SharedCompileArguments>()
-					{
-						expectedCompileArguments,
-					},
-					compiler.GetCompileRequests());
-				Assert.Equal(
-					new List<LinkArguments>()
-					{
-						expectedLinkArguments,
-					},
-					compiler.GetLinkRequests());
-
-				var expectedBuildOperations = new List<BuildOperation>()
-				{
-					new BuildOperation(
-						"MakeDir [./obj/]",
-						new Path("C:/root/"),
-						new Path("C:/mkdir.exe"),
-						"\"./obj/\"",
-						new List<Path>(),
-						new List<Path>()
-						{
-							new Path("./obj/"),
-						}),
-					new BuildOperation(
-						"MakeDir [./bin/]",
-						new Path("C:/root/"),
-						new Path("C:/mkdir.exe"),
-						"\"./bin/\"",
-						new List<Path>(),
-						new List<Path>()
-						{
-							new Path("./bin/"),
-						}),
-					new BuildOperation(
-						"MockCompile: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockCompiler.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("TestFile.cpp"),
-						},
-						new List<Path>()
-						{
-							new Path("obj/TestFile.mock.obj"),
-						}),
-					new BuildOperation(
-						"MockLink: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockLinker.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("InputFile.in"),
-						},
-						new List<Path>()
-						{
-							new Path("OutputFile.out"),
-						}),
-				};
-
-				Assert.Equal(
-					expectedBuildOperations,
-					result.BuildOperations);
-
-				Assert.Equal(
-					new List<Path>(),
-					result.ModuleDependencies);
-
-				Assert.Equal(
-					new List<Path>(),
-					result.LinkDependencies);
-
-				Assert.Equal(
-					new List<Path>()
-					{
-						new Path("C:/root/bin/Program.exe"),
-					},
-					result.RuntimeDependencies);
-			}
-		}
-
-		[Fact]
-		public void Build_Library_MultipleFiles()
-		{
-			// Register the test process manager
-			var processManager = new MockProcessManager();
-
-			// Register the test listener
-			var testListener = new TestTraceListener();
-			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
-			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
-			{
-				// Register the mock compiler
-				var compiler = new Mock.Compiler();
-
-				// Setup the build arguments
-				var arguments = new BuildArguments();
-				arguments.TargetName = "Library";
-				arguments.TargetType = BuildTargetType.StaticLibrary;
-				arguments.LanguageStandard = LanguageStandard.CPP20;
-				arguments.WorkingDirectory = new Path("C:/root/");
-				arguments.ObjectDirectory = new Path("obj/");
-				arguments.BinaryDirectory = new Path("bin/");
-				arguments.SourceFiles = new List<Path>()
-				{
-					new Path("TestFile1.cpp"),
-					new Path("TestFile2.cpp"),
-					new Path("TestFile3.cpp"),
-				};
-				arguments.OptimizationLevel = BuildOptimizationLevel.Size;
-				arguments.IncludeDirectories = new List<Path>()
-				{
-					new Path("Folder"),
-					new Path("AnotherFolder/Sub"),
-				};
-				arguments.ModuleDependencies = new List<Path>()
-				{
-					new Path("../Other/bin/OtherModule1.mock.bmi"),
-					new Path("../OtherModule2.mock.bmi"),
-				};
-				arguments.LinkDependencies = new List<Path>()
-				{
-					new Path("../Other/bin/OtherModule1.mock.a"),
-					new Path("../OtherModule2.mock.a"),
-				};
-
-				var uut = new BuildEngine(compiler);
-				var fileSystemState = new FileSystemState();
-				var readAccessList = new List<Path>();
-				var writeAccessList = new List<Path>();
-				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
-				var result = uut.Execute(buildState, arguments);
-
-				// Verify expected process manager requests
-				Assert.Equal(
-					new List<string>()
-					{
-						"GetCurrentProcessFileName",
-						"GetCurrentProcessFileName",
-					},
-					processManager.GetRequests());
-
-				// Verify expected logs
-				Assert.Equal(
-					new List<string>()
-					{
-						"INFO: Generate Compile Operation: ./TestFile1.cpp",
-						"INFO: Generate Compile Operation: ./TestFile2.cpp",
-						"INFO: Generate Compile Operation: ./TestFile3.cpp",
-						"INFO: CoreLink",
-						"INFO: Linking target",
-						"INFO: Generate Link Operation: ./bin/Library.mock.lib",
-					},
-					testListener.GetMessages());
-
-				// Setup the shared arguments
-				var expectedCompileArguments = new SharedCompileArguments()
-				{
-					Standard = LanguageStandard.CPP20,
-					Optimize = OptimizationLevel.Size,
-					RootDirectory = new Path("C:/root/"),
-					ObjectDirectory = new Path("obj/"),
-					IncludeDirectories = new List<Path>()
-					{
-						new Path("Folder"),
-						new Path("AnotherFolder/Sub"),
-					},
-					IncludeModules = new List<Path>()
-					{
-						new Path("../Other/bin/OtherModule1.mock.bmi"),
-						new Path("../OtherModule2.mock.bmi"),
-					},
-				};
-
-				var expectedTranslationUnit1Arguments = new TranslationUnitCompileArguments();
-				expectedTranslationUnit1Arguments.SourceFile = new Path("TestFile1.cpp");
-				expectedTranslationUnit1Arguments.TargetFile = new Path("obj/TestFile1.mock.obj");
-
-				var expectedTranslationUnit2Arguments = new TranslationUnitCompileArguments();
-				expectedTranslationUnit2Arguments.SourceFile = new Path("TestFile2.cpp");
-				expectedTranslationUnit2Arguments.TargetFile = new Path("obj/TestFile2.mock.obj");
-
-				var expectedTranslationUnit3Arguments = new TranslationUnitCompileArguments();
-				expectedTranslationUnit3Arguments.SourceFile = new Path("TestFile3.cpp");
-				expectedTranslationUnit3Arguments.TargetFile = new Path("obj/TestFile3.mock.obj");
-
-				expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
-				{
-					expectedTranslationUnit1Arguments,
-					expectedTranslationUnit2Arguments,
-					expectedTranslationUnit3Arguments,
-				};
-
-				var expectedLinkArguments = new LinkArguments();
-				expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
-				expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
-				expectedLinkArguments.RootDirectory = new Path("C:/root/");
-				expectedLinkArguments.ObjectFiles = new List<Path>()
-				{
-					new Path("obj/TestFile1.mock.obj"),
-					new Path("obj/TestFile2.mock.obj"),
-					new Path("obj/TestFile3.mock.obj"),
-				};
-
-				// Note: There is no need to send along the static libraries for a static library linking
-				expectedLinkArguments.LibraryFiles = new List<Path>();
-
-				// Verify expected compiler calls
-				Assert.Equal(
-					new List<SharedCompileArguments>()
-					{
-						expectedCompileArguments,
-					},
-					compiler.GetCompileRequests());
-				Assert.Equal(
-					new List<LinkArguments>()
-					{
-						expectedLinkArguments,
-					},
-					compiler.GetLinkRequests());
-
-				// Verify build state
-				var expectedBuildOperations = new List<BuildOperation>()
-				{
-					new BuildOperation(
-						"MakeDir [./obj/]",
-						new Path("C:/root/"),
-						new Path("C:/mkdir.exe"),
-						"\"./obj/\"",
-						new List<Path>(),
-						new List<Path>()
-						{
-							new Path("./obj/"),
-						}),
-					new BuildOperation(
-						"MakeDir [./bin/]",
-						new Path("C:/root/"),
-						new Path("C:/mkdir.exe"),
-						"\"./bin/\"",
-						new List<Path>(),
-						new List<Path>()
-						{
-							new Path("./bin/"),
-						}),
-					new BuildOperation(
-						"MockCompile: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockCompiler.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("TestFile1.cpp"),
-						},
-						new List<Path>()
-						{
-							new Path("obj/TestFile1.mock.obj"),
-						}),
-					new BuildOperation(
-						"MockCompile: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockCompiler.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("TestFile2.cpp"),
-						},
-						new List<Path>()
-						{
-							new Path("obj/TestFile2.mock.obj"),
-						}),
-					new BuildOperation(
-						"MockCompile: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockCompiler.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("TestFile3.cpp"),
-						},
-						new List<Path>()
-						{
-							new Path("obj/TestFile3.mock.obj"),
-						}),
-					new BuildOperation(
-						"MockLink: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockLinker.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("InputFile.in"),
-						},
-						new List<Path>()
-						{
-							new Path("OutputFile.out"),
-						}),
-				};
-
-				Assert.Equal(
-					expectedBuildOperations,
-					result.BuildOperations);
-
-				Assert.Equal(
-					new List<Path>(),
-					result.ModuleDependencies);
-
-				Assert.Equal(
-					new List<Path>()
-					{
-						new Path("../Other/bin/OtherModule1.mock.a"),
-						new Path("../OtherModule2.mock.a"),
-						new Path("C:/root/bin/Library.mock.lib"),
-					},
-					result.LinkDependencies);
-
-				Assert.Equal(
-					new List<Path>(),
-					result.RuntimeDependencies);
-
-				Assert.Equal(
-					new Path(),
-					result.TargetFile);
-			}
-		}
-
-		[Fact]
-		public void Build_Library_ModuleInterface()
-		{
-			// Register the test process manager
-			var processManager = new MockProcessManager();
-
-			// Register the test listener
-			var testListener = new TestTraceListener();
-			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
-			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
-			{
-				// Register the mock compiler
-				var compiler = new Mock.Compiler();
-
-				// Setup the build arguments
-				var arguments = new BuildArguments();
-				arguments.TargetName = "Library";
-				arguments.TargetType = BuildTargetType.StaticLibrary;
-				arguments.LanguageStandard = LanguageStandard.CPP20;
-				arguments.WorkingDirectory = new Path("C:/root/");
-				arguments.ObjectDirectory = new Path("obj/");
-				arguments.BinaryDirectory = new Path("bin/");
-				arguments.ModuleInterfaceSourceFile = new Path("Public.cpp");
-				arguments.SourceFiles = new List<Path>()
-				{
-					new Path("TestFile1.cpp"),
-					new Path("TestFile2.cpp"),
-					new Path("TestFile3.cpp"),
-				};
-				arguments.OptimizationLevel = BuildOptimizationLevel.None;
-				arguments.IncludeDirectories = new List<Path>()
-				{
-					new Path("Folder"),
-					new Path("AnotherFolder/Sub"),
-				};
-				arguments.ModuleDependencies = new List<Path>()
-				{
-					new Path("../Other/bin/OtherModule1.mock.bmi"),
-					new Path("../OtherModule2.mock.bmi"),
-				};
-				arguments.LinkDependencies = new List<Path>()
-				{
-					new Path("../Other/bin/OtherModule1.mock.a"),
-					new Path("../OtherModule2.mock.a"),
-				};
-				arguments.PreprocessorDefinitions = new List<string>()
-				{
-					"DEBUG",
-					"AWESOME",
-				};
-
-				var uut = new BuildEngine(compiler);
-				var fileSystemState = new FileSystemState();
-				var readAccessList = new List<Path>();
-				var writeAccessList = new List<Path>();
-				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
-				var result = uut.Execute(buildState, arguments);
-
-				// Verify expected process manager requests
-				Assert.Equal(
-					new List<string>()
-					{
-						"GetCurrentProcessFileName",
-						"GetCurrentProcessFileName",
-						"GetCurrentProcessFileName",
-					},
-					processManager.GetRequests());
-
-				// Verify expected logs
-				Assert.Equal(
-					new List<string>()
-					{
-						"INFO: Generate Module Unit Compile: ./Public.cpp",
-						"INFO: Generate Compile Operation: ./TestFile1.cpp",
-						"INFO: Generate Compile Operation: ./TestFile2.cpp",
-						"INFO: Generate Compile Operation: ./TestFile3.cpp",
-						"INFO: CoreLink",
-						"INFO: Linking target",
-						"INFO: Generate Link Operation: ./bin/Library.mock.lib",
-					},
-					testListener.GetMessages());
-
-				// Setup the shared arguments
-				var expectedCompileArguments = new SharedCompileArguments()
-				{
-					Standard = LanguageStandard.CPP20,
-					Optimize = OptimizationLevel.None,
-					RootDirectory = new Path("C:/root/"),
-					ObjectDirectory = new Path("obj/"),
-					IncludeDirectories = new List<Path>()
-					{
-						new Path("Folder"),
-						new Path("AnotherFolder/Sub"),
-					},
-					IncludeModules = new List<Path>()
-					{
-						new Path("../Other/bin/OtherModule1.mock.bmi"),
-						new Path("../OtherModule2.mock.bmi"),
-					},
-					PreprocessorDefinitions = new List<string>()
-					{
-						"DEBUG",
-						"AWESOME",
-					},
-				};
-
-				var expectedCompileModuleArguments = new InterfaceUnitCompileArguments()
-				{
-					SourceFile = new Path("Public.cpp"),
-					TargetFile = new Path("obj/Public.mock.obj"),
-					ModuleInterfaceTarget = new Path("obj/Public.mock.bmi"),
-				};
-				expectedCompileArguments.InterfaceUnit = expectedCompileModuleArguments;
-
-				var expectedTranslationUnit1Arguments = new TranslationUnitCompileArguments();
-				expectedTranslationUnit1Arguments.SourceFile = new Path("TestFile1.cpp");
-				expectedTranslationUnit1Arguments.TargetFile = new Path("obj/TestFile1.mock.obj");
-
-				var expectedTranslationUnit2Arguments = new TranslationUnitCompileArguments();
-				expectedTranslationUnit2Arguments.SourceFile = new Path("TestFile2.cpp");
-				expectedTranslationUnit2Arguments.TargetFile = new Path("obj/TestFile2.mock.obj");
-
-				var expectedTranslationUnit3Arguments = new TranslationUnitCompileArguments();
-				expectedTranslationUnit3Arguments.SourceFile = new Path("TestFile3.cpp");
-				expectedTranslationUnit3Arguments.TargetFile = new Path("obj/TestFile3.mock.obj");
-
-				expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
-				{
-					expectedTranslationUnit1Arguments,
-					expectedTranslationUnit2Arguments,
-					expectedTranslationUnit3Arguments,
-				};
-
-				var expectedLinkArguments = new LinkArguments();
-				expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
-				expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
-				expectedLinkArguments.RootDirectory = new Path("C:/root/");
-				expectedLinkArguments.ObjectFiles = new List<Path>()
-				{
-					new Path("obj/TestFile1.mock.obj"),
-					new Path("obj/TestFile2.mock.obj"),
-					new Path("obj/TestFile3.mock.obj"),
-					new Path("obj/Public.mock.obj"),
-				};
-				expectedLinkArguments.LibraryFiles = new List<Path>();
-
-				// Verify expected compiler calls
-				Assert.Equal(
-					new List<SharedCompileArguments>()
-					{
-						expectedCompileArguments,
-					},
-					compiler.GetCompileRequests());
-				Assert.Equal(
-					new List<LinkArguments>()
-					{
-						expectedLinkArguments,
-					},
-					compiler.GetLinkRequests());
-
-				// Verify build state
-				var expectedBuildOperations = new List<BuildOperation>()
-				{
-					new BuildOperation(
-						"MakeDir [./obj/]",
-						new Path("C:/root/"),
-						new Path("C:/mkdir.exe"),
-						"\"./obj/\"",
-						new List<Path>(),
-						new List<Path>()
-						{
-						new Path("./obj/"),
-						}),
-					new BuildOperation(
-						"MakeDir [./bin/]",
-						new Path("C:/root/"),
-						new Path("C:/mkdir.exe"),
-						"\"./bin/\"",
-						new List<Path>(),
-						new List<Path>()
-						{
-							new Path("./bin/"),
-						}),
-					new BuildOperation(
-						"Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
-						new Path("C:/root/"),
-						new Path("C:/copy.exe"),
-						"\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
-						new List<Path>()
-						{
-							new Path("./obj/Public.mock.bmi"),
-						},
-						new List<Path>()
-						{
-							new Path("./bin/Library.mock.bmi"),
-						}),
-					new BuildOperation(
-						"MockCompileModule: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockCompiler.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("InputFile.in"),
-						},
-						new List<Path>()
-						{
-							new Path("OutputFile.out"),
-						}),
-					new BuildOperation(
-						"MockCompile: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockCompiler.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("TestFile1.cpp"),
-						},
-						new List<Path>()
-						{
-							new Path("obj/TestFile1.mock.obj"),
-						}),
-					new BuildOperation(
-						"MockCompile: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockCompiler.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("TestFile2.cpp"),
-						},
-						new List<Path>()
-						{
-							new Path("obj/TestFile2.mock.obj"),
-						}),
-					new BuildOperation(
-						"MockCompile: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockCompiler.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("TestFile3.cpp"),
-						},
-						new List<Path>()
-						{
-							new Path("obj/TestFile3.mock.obj"),
-						}),
-					new BuildOperation(
-						"MockLink: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockLinker.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("InputFile.in"),
-						},
-						new List<Path>()
-						{
-							new Path("OutputFile.out"),
-						}),
-				};
-
-				Assert.Equal(
-					expectedBuildOperations,
-					result.BuildOperations);
-
-				Assert.Equal(
-					new List<Path>()
-					{
-					new Path("C:/root/bin/Library.mock.bmi"),
-					},
-					result.ModuleDependencies);
-
-				Assert.Equal(
-					new List<Path>()
-					{
-					new Path("../Other/bin/OtherModule1.mock.a"),
-					new Path("../OtherModule2.mock.a"),
-					new Path("C:/root/bin/Library.mock.lib"),
-					},
-					result.LinkDependencies);
-
-				Assert.Equal(
-					new List<Path>(),
-					result.RuntimeDependencies);
-
-				Assert.Equal(
-					new Path(),
-					result.TargetFile);
-			}
-		}
-
-		[Fact]
-		public void Build_Library_ModuleInterfaceNoSource()
-		{
-			// Register the test process manager
-			var processManager = new MockProcessManager();
-
-			// Register the test listener
-			var testListener = new TestTraceListener();
-			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
-			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
-			{
-				// Register the mock compiler
-				var compiler = new Mock.Compiler();
-
-				// Setup the build arguments
-				var arguments = new BuildArguments();
-				arguments.TargetName = "Library";
-				arguments.TargetType = BuildTargetType.StaticLibrary;
-				arguments.LanguageStandard = LanguageStandard.CPP20;
-				arguments.WorkingDirectory = new Path("C:/root/");
-				arguments.ObjectDirectory = new Path("obj/");
-				arguments.BinaryDirectory = new Path("bin/");
-				arguments.ModuleInterfaceSourceFile = new Path("Public.cpp");
-				arguments.SourceFiles = new List<Path>();
-				arguments.OptimizationLevel = BuildOptimizationLevel.Size;
-				arguments.IncludeDirectories = new List<Path>()
-				{
-					new Path("Folder"),
-					new Path("AnotherFolder/Sub"),
-				};
-				arguments.ModuleDependencies = new List<Path>()
-				{
-					new Path("../Other/bin/OtherModule1.mock.bmi"),
-					new Path("../OtherModule2.mock.bmi"),
-				};
-				arguments.LinkDependencies = new List<Path>()
-				{
-					new Path("../Other/bin/OtherModule1.mock.a"),
-					new Path("../OtherModule2.mock.a"),
-				};
-
-				var uut = new BuildEngine(compiler);
-				var fileSystemState = new FileSystemState();
-				var readAccessList = new List<Path>();
-				var writeAccessList = new List<Path>();
-				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
-				var result = uut.Execute(buildState, arguments);
-
-				// Verify expected process manager requests
-				Assert.Equal(
-					new List<string>()
-					{
-						"GetCurrentProcessFileName",
-						"GetCurrentProcessFileName",
-						"GetCurrentProcessFileName",
-					},
-					processManager.GetRequests());
-
-				// Verify expected logs
-				Assert.Equal(
-					new List<string>()
-					{
-						"INFO: Generate Module Unit Compile: ./Public.cpp",
-						"INFO: CoreLink",
-						"INFO: Linking target",
-						"INFO: Generate Link Operation: ./bin/Library.mock.lib",
-					},
-					testListener.GetMessages());
-
-				// Setup the shared arguments
-				var expectedCompileArguments = new SharedCompileArguments()
-				{
-					Standard = LanguageStandard.CPP20,
-					Optimize = OptimizationLevel.Size,
-					RootDirectory = new Path("C:/root/"),
-					ObjectDirectory = new Path("obj/"),
-					IncludeDirectories = new List<Path>()
-					{
-						new Path("Folder"),
-						new Path("AnotherFolder/Sub"),
-					},
-					IncludeModules = new List<Path>()
-					{
-						new Path("../Other/bin/OtherModule1.mock.bmi"),
-						new Path("../OtherModule2.mock.bmi"),
-					},
-				};
-
-				var expectedCompileModuleArguments = new InterfaceUnitCompileArguments()
-				{
-					SourceFile = new Path("Public.cpp"),
-					TargetFile = new Path("obj/Public.mock.obj"),
-					ModuleInterfaceTarget = new Path("obj/Public.mock.bmi"),
-				};
-				expectedCompileArguments.InterfaceUnit = expectedCompileModuleArguments;
-
-				var expectedLinkArguments = new LinkArguments();
-				expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
-				expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
-				expectedLinkArguments.RootDirectory = new Path("C:/root/");
-				expectedLinkArguments.ObjectFiles = new List<Path>()
-				{
-					new Path("obj/Public.mock.obj"),
-				};
-				expectedLinkArguments.LibraryFiles = new List<Path>();
-
-				// Verify expected compiler calls
-				Assert.Equal(
-					new List<SharedCompileArguments>()
-					{
-						expectedCompileArguments,
-					},
-					compiler.GetCompileRequests());
-				Assert.Equal(
-					new List<LinkArguments>()
-					{
-						expectedLinkArguments,
-					},
-					compiler.GetLinkRequests());
-
-				// Verify build state
-				var expectedBuildOperations = new List<BuildOperation>()
-				{
-					new BuildOperation(
-						"MakeDir [./obj/]",
-						new Path("C:/root/"),
-						new Path("C:/mkdir.exe"),
-						"\"./obj/\"",
-						new List<Path>(),
-						new List<Path>()
-						{
-							new Path("./obj/"),
-						}),
-					new BuildOperation(
-						"MakeDir [./bin/]",
-						new Path("C:/root/"),
-						new Path("C:/mkdir.exe"),
-						"\"./bin/\"",
-						new List<Path>(),
-						new List<Path>()
-						{
-							new Path("./bin/"),
-						}),
-					new BuildOperation(
-						"Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
-						new Path("C:/root/"),
-						new Path("C:/copy.exe"),
-						"\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
-						new List<Path>()
-						{
-							new Path("./obj/Public.mock.bmi"),
-						},
-						new List<Path>()
-						{
-							new Path("./bin/Library.mock.bmi"),
-						}),
-					new BuildOperation(
-						"MockCompileModule: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockCompiler.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("InputFile.in"),
-						},
-						new List<Path>()
-						{
-							new Path("OutputFile.out"),
-						}),
-					new BuildOperation(
-						"MockLink: 1",
-						new Path("MockWorkingDirectory"),
-						new Path("MockLinker.exe"),
-						"Arguments",
-						new List<Path>()
-						{
-							new Path("InputFile.in"),
-						},
-						new List<Path>()
-						{
-							new Path("OutputFile.out"),
-						}),
-				};
-
-				Assert.Equal(
-					expectedBuildOperations,
-					result.BuildOperations);
-
-				Assert.Equal(
-					new List<Path>()
-					{
-						new Path("C:/root/bin/Library.mock.bmi"),
-					},
-					result.ModuleDependencies);
-
-				Assert.Equal(
-					new List<Path>()
-					{
-						new Path("../Other/bin/OtherModule1.mock.a"),
-						new Path("../OtherModule2.mock.a"),
-						new Path("C:/root/bin/Library.mock.lib"),
-					},
-					result.LinkDependencies);
-
-				Assert.Equal(
-					new List<Path>(),
-					result.RuntimeDependencies);
-
-				Assert.Equal(
-					new Path(),
-					result.TargetFile);
-			}
-		}
-	}
+    public class BuildEngineUnitTests
+    {
+        [Fact]
+        public void Initialize_Success()
+        {
+            var compiler = new Mock.Compiler();
+            var uut = new BuildEngine(compiler);
+        }
+
+        [Fact]
+        public void Build_Executable()
+        {
+            // Register the test process manager
+            var processManager = new MockProcessManager();
+
+            // Register the test listener
+            var testListener = new TestTraceListener();
+            using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+            using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+            {
+                // Register the mock compiler
+                var compiler = new Mock.Compiler();
+
+                // Register the test process manager
+
+                // Setup the build arguments
+                var arguments = new BuildArguments();
+                arguments.TargetName = "Program";
+                arguments.TargetType = BuildTargetType.Executable;
+                arguments.LanguageStandard = LanguageStandard.CPP20;
+                arguments.SourceRootDirectory = new Path("C:/source/");
+                arguments.TargetRootDirectory = new Path("C:/target/");
+                arguments.ObjectDirectory = new Path("obj/");
+                arguments.BinaryDirectory = new Path("bin/");
+                arguments.SourceFiles = new List<Path>()
+                {
+                    new Path("TestFile.cpp"),
+                };
+                arguments.OptimizationLevel = BuildOptimizationLevel.None;
+                arguments.LinkDependencies = new List<Path>()
+                {
+                    new Path("../Other/bin/OtherModule1.mock.a"),
+                    new Path("../OtherModule2.mock.a"),
+                };
+
+                var uut = new BuildEngine(compiler);
+                var fileSystemState = new FileSystemState();
+                var readAccessList = new List<Path>();
+                var writeAccessList = new List<Path>();
+                var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+                var result = uut.Execute(buildState, arguments);
+
+                // Verify expected process manager requests
+                Assert.Equal(
+                    new List<string>()
+                    {
+                        "GetCurrentProcessFileName",
+                        "GetCurrentProcessFileName",
+                    },
+                    processManager.GetRequests());
+
+                // Verify expected logs
+                Assert.Equal(
+                    new List<string>()
+                    {
+                        "INFO: Generate Compile Operation: ./TestFile.cpp",
+                        "INFO: CoreLink",
+                        "INFO: Linking target",
+                        "INFO: Generate Link Operation: ./bin/Program.exe",
+                    },
+                    testListener.GetMessages());
+
+                var expectedCompileArguments = new SharedCompileArguments()
+                {
+                    Standard = LanguageStandard.CPP20,
+                    Optimize = OptimizationLevel.None,
+                    ObjectDirectory = new Path("obj/"),
+                    SourceRootDirectory = new Path("C:/source/"),
+                    TargetRootDirectory = new Path("C:/target/"),
+                };
+
+                var expectedTranslationUnitArguments = new TranslationUnitCompileArguments()
+                {
+                    SourceFile = new Path("TestFile.cpp"),
+                    TargetFile = new Path("obj/TestFile.mock.obj"),
+                };
+                expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
+                {
+                    expectedTranslationUnitArguments,
+                };
+
+                var expectedLinkArguments = new LinkArguments();
+                expectedLinkArguments.TargetType = LinkTarget.Executable;
+                expectedLinkArguments.TargetFile = new Path("bin/Program.exe");
+                expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+                expectedLinkArguments.ObjectFiles = new List<Path>()
+                {
+                    new Path("obj/TestFile.mock.obj"),
+                };
+                expectedLinkArguments.LibraryFiles = new List<Path>()
+                {
+                    new Path("../Other/bin/OtherModule1.mock.a"),
+                    new Path("../OtherModule2.mock.a"),
+                };
+
+                // Verify expected compiler calls
+                Assert.Equal(
+                    new List<SharedCompileArguments>()
+                    {
+                        expectedCompileArguments,
+                    },
+                    compiler.GetCompileRequests());
+                Assert.Equal(
+                    new List<LinkArguments>()
+                    {
+                        expectedLinkArguments,
+                    },
+                    compiler.GetLinkRequests());
+
+                var expectedBuildOperations = new List<BuildOperation>()
+                {
+                    new BuildOperation(
+                        "MakeDir [./obj/]",
+                        new Path("C:/target/"),
+                        new Path("C:/mkdir.exe"),
+                        "\"./obj/\"",
+                        new List<Path>(),
+                        new List<Path>()
+                        {
+                            new Path("./obj/"),
+                        }),
+                    new BuildOperation(
+                        "MakeDir [./bin/]",
+                        new Path("C:/target/"),
+                        new Path("C:/mkdir.exe"),
+                        "\"./bin/\"",
+                        new List<Path>(),
+                        new List<Path>()
+                        {
+                            new Path("./bin/"),
+                        }),
+                    new BuildOperation(
+                        "MockCompile: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockCompiler.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("TestFile.cpp"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("obj/TestFile.mock.obj"),
+                        }),
+                    new BuildOperation(
+                        "MockLink: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockLinker.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("InputFile.in"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("OutputFile.out"),
+                        }),
+                };
+
+                Assert.Equal(
+                    expectedBuildOperations,
+                    result.BuildOperations);
+
+                Assert.Equal(
+                    new List<Path>(),
+                    result.ModuleDependencies);
+
+                Assert.Equal(
+                    new List<Path>(),
+                    result.LinkDependencies);
+
+                Assert.Equal(
+                    new List<Path>()
+                    {
+                        new Path("C:/target/bin/Program.exe"),
+                    },
+                    result.RuntimeDependencies);
+            }
+        }
+
+        [Fact]
+        public void Build_Library_MultipleFiles()
+        {
+            // Register the test process manager
+            var processManager = new MockProcessManager();
+
+            // Register the test listener
+            var testListener = new TestTraceListener();
+            using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+            using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+            {
+                // Register the mock compiler
+                var compiler = new Mock.Compiler();
+
+                // Setup the build arguments
+                var arguments = new BuildArguments();
+                arguments.TargetName = "Library";
+                arguments.TargetType = BuildTargetType.StaticLibrary;
+                arguments.LanguageStandard = LanguageStandard.CPP20;
+                arguments.SourceRootDirectory = new Path("C:/source/");
+                arguments.TargetRootDirectory = new Path("C:/target/");
+                arguments.ObjectDirectory = new Path("obj/");
+                arguments.BinaryDirectory = new Path("bin/");
+                arguments.SourceFiles = new List<Path>()
+                {
+                    new Path("TestFile1.cpp"),
+                    new Path("TestFile2.cpp"),
+                    new Path("TestFile3.cpp"),
+                };
+                arguments.OptimizationLevel = BuildOptimizationLevel.Size;
+                arguments.IncludeDirectories = new List<Path>()
+                {
+                    new Path("Folder"),
+                    new Path("AnotherFolder/Sub"),
+                };
+                arguments.ModuleDependencies = new List<Path>()
+                {
+                    new Path("../Other/bin/OtherModule1.mock.bmi"),
+                    new Path("../OtherModule2.mock.bmi"),
+                };
+                arguments.LinkDependencies = new List<Path>()
+                {
+                    new Path("../Other/bin/OtherModule1.mock.a"),
+                    new Path("../OtherModule2.mock.a"),
+                };
+
+                var uut = new BuildEngine(compiler);
+                var fileSystemState = new FileSystemState();
+                var readAccessList = new List<Path>();
+                var writeAccessList = new List<Path>();
+                var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+                var result = uut.Execute(buildState, arguments);
+
+                // Verify expected process manager requests
+                Assert.Equal(
+                    new List<string>()
+                    {
+                        "GetCurrentProcessFileName",
+                        "GetCurrentProcessFileName",
+                    },
+                    processManager.GetRequests());
+
+                // Verify expected logs
+                Assert.Equal(
+                    new List<string>()
+                    {
+                        "INFO: Generate Compile Operation: ./TestFile1.cpp",
+                        "INFO: Generate Compile Operation: ./TestFile2.cpp",
+                        "INFO: Generate Compile Operation: ./TestFile3.cpp",
+                        "INFO: CoreLink",
+                        "INFO: Linking target",
+                        "INFO: Generate Link Operation: ./bin/Library.mock.lib",
+                    },
+                    testListener.GetMessages());
+
+                // Setup the shared arguments
+                var expectedCompileArguments = new SharedCompileArguments()
+                {
+                    Standard = LanguageStandard.CPP20,
+                    Optimize = OptimizationLevel.Size,
+                    SourceRootDirectory = new Path("C:/source/"),
+                    TargetRootDirectory = new Path("C:/target/"),
+                    ObjectDirectory = new Path("obj/"),
+                    IncludeDirectories = new List<Path>()
+                    {
+                        new Path("Folder"),
+                        new Path("AnotherFolder/Sub"),
+                    },
+                    IncludeModules = new List<Path>()
+                    {
+                        new Path("../Other/bin/OtherModule1.mock.bmi"),
+                        new Path("../OtherModule2.mock.bmi"),
+                    },
+                };
+
+                var expectedTranslationUnit1Arguments = new TranslationUnitCompileArguments();
+                expectedTranslationUnit1Arguments.SourceFile = new Path("TestFile1.cpp");
+                expectedTranslationUnit1Arguments.TargetFile = new Path("obj/TestFile1.mock.obj");
+
+                var expectedTranslationUnit2Arguments = new TranslationUnitCompileArguments();
+                expectedTranslationUnit2Arguments.SourceFile = new Path("TestFile2.cpp");
+                expectedTranslationUnit2Arguments.TargetFile = new Path("obj/TestFile2.mock.obj");
+
+                var expectedTranslationUnit3Arguments = new TranslationUnitCompileArguments();
+                expectedTranslationUnit3Arguments.SourceFile = new Path("TestFile3.cpp");
+                expectedTranslationUnit3Arguments.TargetFile = new Path("obj/TestFile3.mock.obj");
+
+                expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
+                {
+                    expectedTranslationUnit1Arguments,
+                    expectedTranslationUnit2Arguments,
+                    expectedTranslationUnit3Arguments,
+                };
+
+                var expectedLinkArguments = new LinkArguments();
+                expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
+                expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
+                expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+                expectedLinkArguments.ObjectFiles = new List<Path>()
+                {
+                    new Path("obj/TestFile1.mock.obj"),
+                    new Path("obj/TestFile2.mock.obj"),
+                    new Path("obj/TestFile3.mock.obj"),
+                };
+
+                // Note: There is no need to send along the static libraries for a static library linking
+                expectedLinkArguments.LibraryFiles = new List<Path>();
+
+                // Verify expected compiler calls
+                Assert.Equal(
+                    new List<SharedCompileArguments>()
+                    {
+                        expectedCompileArguments,
+                    },
+                    compiler.GetCompileRequests());
+                Assert.Equal(
+                    new List<LinkArguments>()
+                    {
+                        expectedLinkArguments,
+                    },
+                    compiler.GetLinkRequests());
+
+                // Verify build state
+                var expectedBuildOperations = new List<BuildOperation>()
+                {
+                    new BuildOperation(
+                        "MakeDir [./obj/]",
+                        new Path("C:/target/"),
+                        new Path("C:/mkdir.exe"),
+                        "\"./obj/\"",
+                        new List<Path>(),
+                        new List<Path>()
+                        {
+                            new Path("./obj/"),
+                        }),
+                    new BuildOperation(
+                        "MakeDir [./bin/]",
+                        new Path("C:/target/"),
+                        new Path("C:/mkdir.exe"),
+                        "\"./bin/\"",
+                        new List<Path>(),
+                        new List<Path>()
+                        {
+                            new Path("./bin/"),
+                        }),
+                    new BuildOperation(
+                        "MockCompile: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockCompiler.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("TestFile1.cpp"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("obj/TestFile1.mock.obj"),
+                        }),
+                    new BuildOperation(
+                        "MockCompile: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockCompiler.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("TestFile2.cpp"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("obj/TestFile2.mock.obj"),
+                        }),
+                    new BuildOperation(
+                        "MockCompile: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockCompiler.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("TestFile3.cpp"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("obj/TestFile3.mock.obj"),
+                        }),
+                    new BuildOperation(
+                        "MockLink: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockLinker.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("InputFile.in"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("OutputFile.out"),
+                        }),
+                };
+
+                Assert.Equal(
+                    expectedBuildOperations,
+                    result.BuildOperations);
+
+                Assert.Equal(
+                    new List<Path>(),
+                    result.ModuleDependencies);
+
+                Assert.Equal(
+                    new List<Path>()
+                    {
+                        new Path("../Other/bin/OtherModule1.mock.a"),
+                        new Path("../OtherModule2.mock.a"),
+                        new Path("C:/target/bin/Library.mock.lib"),
+                    },
+                    result.LinkDependencies);
+
+                Assert.Equal(
+                    new List<Path>(),
+                    result.RuntimeDependencies);
+
+                Assert.Equal(
+                    new Path(),
+                    result.TargetFile);
+            }
+        }
+
+        [Fact]
+        public void Build_Library_ModuleInterface()
+        {
+            // Register the test process manager
+            var processManager = new MockProcessManager();
+
+            // Register the test listener
+            var testListener = new TestTraceListener();
+            using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+            using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+            {
+                // Register the mock compiler
+                var compiler = new Mock.Compiler();
+
+                // Setup the build arguments
+                var arguments = new BuildArguments();
+                arguments.TargetName = "Library";
+                arguments.TargetType = BuildTargetType.StaticLibrary;
+                arguments.LanguageStandard = LanguageStandard.CPP20;
+                arguments.SourceRootDirectory = new Path("C:/source/");
+                arguments.TargetRootDirectory = new Path("C:/target/");
+                arguments.ObjectDirectory = new Path("obj/");
+                arguments.BinaryDirectory = new Path("bin/");
+                arguments.ModuleInterfaceSourceFile = new Path("Public.cpp");
+                arguments.SourceFiles = new List<Path>()
+                {
+                    new Path("TestFile1.cpp"),
+                    new Path("TestFile2.cpp"),
+                    new Path("TestFile3.cpp"),
+                };
+                arguments.OptimizationLevel = BuildOptimizationLevel.None;
+                arguments.IncludeDirectories = new List<Path>()
+                {
+                    new Path("Folder"),
+                    new Path("AnotherFolder/Sub"),
+                };
+                arguments.ModuleDependencies = new List<Path>()
+                {
+                    new Path("../Other/bin/OtherModule1.mock.bmi"),
+                    new Path("../OtherModule2.mock.bmi"),
+                };
+                arguments.LinkDependencies = new List<Path>()
+                {
+                    new Path("../Other/bin/OtherModule1.mock.a"),
+                    new Path("../OtherModule2.mock.a"),
+                };
+                arguments.PreprocessorDefinitions = new List<string>()
+                {
+                    "DEBUG",
+                    "AWESOME",
+                };
+
+                var uut = new BuildEngine(compiler);
+                var fileSystemState = new FileSystemState();
+                var readAccessList = new List<Path>();
+                var writeAccessList = new List<Path>();
+                var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+                var result = uut.Execute(buildState, arguments);
+
+                // Verify expected process manager requests
+                Assert.Equal(
+                    new List<string>()
+                    {
+                        "GetCurrentProcessFileName",
+                        "GetCurrentProcessFileName",
+                        "GetCurrentProcessFileName",
+                    },
+                    processManager.GetRequests());
+
+                // Verify expected logs
+                Assert.Equal(
+                    new List<string>()
+                    {
+                        "INFO: Generate Module Unit Compile: ./Public.cpp",
+                        "INFO: Generate Compile Operation: ./TestFile1.cpp",
+                        "INFO: Generate Compile Operation: ./TestFile2.cpp",
+                        "INFO: Generate Compile Operation: ./TestFile3.cpp",
+                        "INFO: CoreLink",
+                        "INFO: Linking target",
+                        "INFO: Generate Link Operation: ./bin/Library.mock.lib",
+                    },
+                    testListener.GetMessages());
+
+                // Setup the shared arguments
+                var expectedCompileArguments = new SharedCompileArguments()
+                {
+                    Standard = LanguageStandard.CPP20,
+                    Optimize = OptimizationLevel.None,
+                    SourceRootDirectory = new Path("C:/source/"),
+                    TargetRootDirectory = new Path("C:/target/"),
+                    ObjectDirectory = new Path("obj/"),
+                    IncludeDirectories = new List<Path>()
+                    {
+                        new Path("Folder"),
+                        new Path("AnotherFolder/Sub"),
+                    },
+                    IncludeModules = new List<Path>()
+                    {
+                        new Path("../Other/bin/OtherModule1.mock.bmi"),
+                        new Path("../OtherModule2.mock.bmi"),
+                    },
+                    PreprocessorDefinitions = new List<string>()
+                    {
+                        "DEBUG",
+                        "AWESOME",
+                    },
+                };
+
+                var expectedCompileModuleArguments = new InterfaceUnitCompileArguments()
+                {
+                    SourceFile = new Path("Public.cpp"),
+                    TargetFile = new Path("obj/Public.mock.obj"),
+                    ModuleInterfaceTarget = new Path("obj/Public.mock.bmi"),
+                };
+                expectedCompileArguments.InterfaceUnit = expectedCompileModuleArguments;
+
+                var expectedTranslationUnit1Arguments = new TranslationUnitCompileArguments();
+                expectedTranslationUnit1Arguments.SourceFile = new Path("TestFile1.cpp");
+                expectedTranslationUnit1Arguments.TargetFile = new Path("obj/TestFile1.mock.obj");
+
+                var expectedTranslationUnit2Arguments = new TranslationUnitCompileArguments();
+                expectedTranslationUnit2Arguments.SourceFile = new Path("TestFile2.cpp");
+                expectedTranslationUnit2Arguments.TargetFile = new Path("obj/TestFile2.mock.obj");
+
+                var expectedTranslationUnit3Arguments = new TranslationUnitCompileArguments();
+                expectedTranslationUnit3Arguments.SourceFile = new Path("TestFile3.cpp");
+                expectedTranslationUnit3Arguments.TargetFile = new Path("obj/TestFile3.mock.obj");
+
+                expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
+                {
+                    expectedTranslationUnit1Arguments,
+                    expectedTranslationUnit2Arguments,
+                    expectedTranslationUnit3Arguments,
+                };
+
+                var expectedLinkArguments = new LinkArguments();
+                expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
+                expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
+                expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+                expectedLinkArguments.ObjectFiles = new List<Path>()
+                {
+                    new Path("obj/TestFile1.mock.obj"),
+                    new Path("obj/TestFile2.mock.obj"),
+                    new Path("obj/TestFile3.mock.obj"),
+                    new Path("obj/Public.mock.obj"),
+                };
+                expectedLinkArguments.LibraryFiles = new List<Path>();
+
+                // Verify expected compiler calls
+                Assert.Equal(
+                    new List<SharedCompileArguments>()
+                    {
+                        expectedCompileArguments,
+                    },
+                    compiler.GetCompileRequests());
+                Assert.Equal(
+                    new List<LinkArguments>()
+                    {
+                        expectedLinkArguments,
+                    },
+                    compiler.GetLinkRequests());
+
+                // Verify build state
+                var expectedBuildOperations = new List<BuildOperation>()
+                {
+                    new BuildOperation(
+                        "MakeDir [./obj/]",
+                        new Path("C:/target/"),
+                        new Path("C:/mkdir.exe"),
+                        "\"./obj/\"",
+                        new List<Path>(),
+                        new List<Path>()
+                        {
+                        new Path("./obj/"),
+                        }),
+                    new BuildOperation(
+                        "MakeDir [./bin/]",
+                        new Path("C:/target/"),
+                        new Path("C:/mkdir.exe"),
+                        "\"./bin/\"",
+                        new List<Path>(),
+                        new List<Path>()
+                        {
+                            new Path("./bin/"),
+                        }),
+                    new BuildOperation(
+                        "Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
+                        new Path("C:/target/"),
+                        new Path("C:/copy.exe"),
+                        "\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
+                        new List<Path>()
+                        {
+                            new Path("./obj/Public.mock.bmi"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("./bin/Library.mock.bmi"),
+                        }),
+                    new BuildOperation(
+                        "MockCompileModule: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockCompiler.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("InputFile.in"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("OutputFile.out"),
+                        }),
+                    new BuildOperation(
+                        "MockCompile: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockCompiler.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("TestFile1.cpp"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("obj/TestFile1.mock.obj"),
+                        }),
+                    new BuildOperation(
+                        "MockCompile: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockCompiler.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("TestFile2.cpp"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("obj/TestFile2.mock.obj"),
+                        }),
+                    new BuildOperation(
+                        "MockCompile: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockCompiler.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("TestFile3.cpp"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("obj/TestFile3.mock.obj"),
+                        }),
+                    new BuildOperation(
+                        "MockLink: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockLinker.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("InputFile.in"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("OutputFile.out"),
+                        }),
+                };
+
+                Assert.Equal(
+                    expectedBuildOperations,
+                    result.BuildOperations);
+
+                Assert.Equal(
+                    new List<Path>()
+                    {
+                    new Path("C:/target/bin/Library.mock.bmi"),
+                    },
+                    result.ModuleDependencies);
+
+                Assert.Equal(
+                    new List<Path>()
+                    {
+                        new Path("../Other/bin/OtherModule1.mock.a"),
+                        new Path("../OtherModule2.mock.a"),
+                        new Path("C:/target/bin/Library.mock.lib"),
+                    },
+                    result.LinkDependencies);
+
+                Assert.Equal(
+                    new List<Path>(),
+                    result.RuntimeDependencies);
+
+                Assert.Equal(
+                    new Path(),
+                    result.TargetFile);
+            }
+        }
+
+        [Fact]
+        public void Build_Library_ModuleInterfaceNoSource()
+        {
+            // Register the test process manager
+            var processManager = new MockProcessManager();
+
+            // Register the test listener
+            var testListener = new TestTraceListener();
+            using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+            using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+            {
+                // Register the mock compiler
+                var compiler = new Mock.Compiler();
+
+                // Setup the build arguments
+                var arguments = new BuildArguments();
+                arguments.TargetName = "Library";
+                arguments.TargetType = BuildTargetType.StaticLibrary;
+                arguments.LanguageStandard = LanguageStandard.CPP20;
+                arguments.SourceRootDirectory = new Path("C:/source/");
+                arguments.TargetRootDirectory = new Path("C:/target/");
+                arguments.ObjectDirectory = new Path("obj/");
+                arguments.BinaryDirectory = new Path("bin/");
+                arguments.ModuleInterfaceSourceFile = new Path("Public.cpp");
+                arguments.SourceFiles = new List<Path>();
+                arguments.OptimizationLevel = BuildOptimizationLevel.Size;
+                arguments.IncludeDirectories = new List<Path>()
+                {
+                    new Path("Folder"),
+                    new Path("AnotherFolder/Sub"),
+                };
+                arguments.ModuleDependencies = new List<Path>()
+                {
+                    new Path("../Other/bin/OtherModule1.mock.bmi"),
+                    new Path("../OtherModule2.mock.bmi"),
+                };
+                arguments.LinkDependencies = new List<Path>()
+                {
+                    new Path("../Other/bin/OtherModule1.mock.a"),
+                    new Path("../OtherModule2.mock.a"),
+                };
+
+                var uut = new BuildEngine(compiler);
+                var fileSystemState = new FileSystemState();
+                var readAccessList = new List<Path>();
+                var writeAccessList = new List<Path>();
+                var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+                var result = uut.Execute(buildState, arguments);
+
+                // Verify expected process manager requests
+                Assert.Equal(
+                    new List<string>()
+                    {
+                        "GetCurrentProcessFileName",
+                        "GetCurrentProcessFileName",
+                        "GetCurrentProcessFileName",
+                    },
+                    processManager.GetRequests());
+
+                // Verify expected logs
+                Assert.Equal(
+                    new List<string>()
+                    {
+                        "INFO: Generate Module Unit Compile: ./Public.cpp",
+                        "INFO: CoreLink",
+                        "INFO: Linking target",
+                        "INFO: Generate Link Operation: ./bin/Library.mock.lib",
+                    },
+                    testListener.GetMessages());
+
+                // Setup the shared arguments
+                var expectedCompileArguments = new SharedCompileArguments()
+                {
+                    Standard = LanguageStandard.CPP20,
+                    Optimize = OptimizationLevel.Size,
+                    SourceRootDirectory = new Path("C:/source/"),
+                    TargetRootDirectory = new Path("C:/target/"),
+                    ObjectDirectory = new Path("obj/"),
+                    IncludeDirectories = new List<Path>()
+                    {
+                        new Path("Folder"),
+                        new Path("AnotherFolder/Sub"),
+                    },
+                    IncludeModules = new List<Path>()
+                    {
+                        new Path("../Other/bin/OtherModule1.mock.bmi"),
+                        new Path("../OtherModule2.mock.bmi"),
+                    },
+                };
+
+                var expectedCompileModuleArguments = new InterfaceUnitCompileArguments()
+                {
+                    SourceFile = new Path("Public.cpp"),
+                    TargetFile = new Path("obj/Public.mock.obj"),
+                    ModuleInterfaceTarget = new Path("obj/Public.mock.bmi"),
+                };
+                expectedCompileArguments.InterfaceUnit = expectedCompileModuleArguments;
+
+                var expectedLinkArguments = new LinkArguments();
+                expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
+                expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
+                expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+                expectedLinkArguments.ObjectFiles = new List<Path>()
+                {
+                    new Path("obj/Public.mock.obj"),
+                };
+                expectedLinkArguments.LibraryFiles = new List<Path>();
+
+                // Verify expected compiler calls
+                Assert.Equal(
+                    new List<SharedCompileArguments>()
+                    {
+                        expectedCompileArguments,
+                    },
+                    compiler.GetCompileRequests());
+                Assert.Equal(
+                    new List<LinkArguments>()
+                    {
+                        expectedLinkArguments,
+                    },
+                    compiler.GetLinkRequests());
+
+                // Verify build state
+                var expectedBuildOperations = new List<BuildOperation>()
+                {
+                    new BuildOperation(
+                        "MakeDir [./obj/]",
+                        new Path("C:/target/"),
+                        new Path("C:/mkdir.exe"),
+                        "\"./obj/\"",
+                        new List<Path>(),
+                        new List<Path>()
+                        {
+                            new Path("./obj/"),
+                        }),
+                    new BuildOperation(
+                        "MakeDir [./bin/]",
+                        new Path("C:/target/"),
+                        new Path("C:/mkdir.exe"),
+                        "\"./bin/\"",
+                        new List<Path>(),
+                        new List<Path>()
+                        {
+                            new Path("./bin/"),
+                        }),
+                    new BuildOperation(
+                        "Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
+                        new Path("C:/target/"),
+                        new Path("C:/copy.exe"),
+                        "\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
+                        new List<Path>()
+                        {
+                            new Path("./obj/Public.mock.bmi"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("./bin/Library.mock.bmi"),
+                        }),
+                    new BuildOperation(
+                        "MockCompileModule: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockCompiler.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("InputFile.in"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("OutputFile.out"),
+                        }),
+                    new BuildOperation(
+                        "MockLink: 1",
+                        new Path("MockWorkingDirectory"),
+                        new Path("MockLinker.exe"),
+                        "Arguments",
+                        new List<Path>()
+                        {
+                            new Path("InputFile.in"),
+                        },
+                        new List<Path>()
+                        {
+                            new Path("OutputFile.out"),
+                        }),
+                };
+
+                Assert.Equal(
+                    expectedBuildOperations,
+                    result.BuildOperations);
+
+                Assert.Equal(
+                    new List<Path>()
+                    {
+                        new Path("C:/target/bin/Library.mock.bmi"),
+                    },
+                    result.ModuleDependencies);
+
+                Assert.Equal(
+                    new List<Path>()
+                    {
+                        new Path("../Other/bin/OtherModule1.mock.a"),
+                        new Path("../OtherModule2.mock.a"),
+                        new Path("C:/target/bin/Library.mock.lib"),
+                    },
+                    result.LinkDependencies);
+
+                Assert.Equal(
+                    new List<Path>(),
+                    result.RuntimeDependencies);
+
+                Assert.Equal(
+                    new Path(),
+                    result.TargetFile);
+            }
+        }
+    }
 }

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildArguments.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildArguments.cs
@@ -84,9 +84,14 @@ namespace Soup.Build.Cpp.Compiler
 		public LanguageStandard LanguageStandard { get; set; }
 
 		/// <summary>
-		/// Gets or sets the working directory
+		/// Gets or sets the source directory
 		/// </summary>
-		public Path WorkingDirectory { get; set; } = new Path();
+		public Path SourceRootDirectory { get; set; } = new Path();
+
+		/// <summary>
+		/// Gets or sets the target directory
+		/// </summary>
+		public Path TargetRootDirectory { get; set; } = new Path();
 
 		/// <summary>
 		/// Gets or sets the output object directory

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildEngine.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildEngine.cs
@@ -38,11 +38,11 @@ namespace Soup.Build.Cpp.Compiler
 			// Ensure the output directories exists as the first step
 			result.BuildOperations.Add(
 				SharedOperations.CreateCreateDirectoryOperation(
-					arguments.WorkingDirectory,
+					arguments.TargetRootDirectory,
 					arguments.ObjectDirectory));
 			result.BuildOperations.Add(
 				SharedOperations.CreateCreateDirectoryOperation(
-					arguments.WorkingDirectory,
+					arguments.TargetRootDirectory,
 					arguments.BinaryDirectory));
 
 			// Perform the core compilation of the source files
@@ -73,7 +73,8 @@ namespace Soup.Build.Cpp.Compiler
 				{
 					Standard = arguments.LanguageStandard,
 					Optimize = Convert(arguments.OptimizationLevel),
-					RootDirectory = arguments.WorkingDirectory,
+					SourceRootDirectory = arguments.SourceRootDirectory,
+					TargetRootDirectory = arguments.TargetRootDirectory,
 					ObjectDirectory = arguments.ObjectDirectory,
 					IncludeDirectories = arguments.IncludeDirectories,
 					IncludeModules = arguments.ModuleDependencies,
@@ -113,7 +114,7 @@ namespace Soup.Build.Cpp.Compiler
 					// Copy the binary module interface to the binary directory after compiling
 					var copyInterfaceOperation =
 						SharedOperations.CreateCopyFileOperation(
-							arguments.WorkingDirectory,
+							arguments.TargetRootDirectory,
 							objectModuleInterfaceFile,
 							binaryOutputModuleInterfaceFile);
 					result.BuildOperations.Add(copyInterfaceOperation);
@@ -122,7 +123,9 @@ namespace Soup.Build.Cpp.Compiler
 					// This will allow the module implementation units access as well as downstream
 					// dependencies to the public interface.
 					result.ModuleDependencies.Add(
-						binaryOutputModuleInterfaceFile.HasRoot ? binaryOutputModuleInterfaceFile : arguments.WorkingDirectory + binaryOutputModuleInterfaceFile);
+						binaryOutputModuleInterfaceFile.HasRoot ?
+							binaryOutputModuleInterfaceFile :
+							arguments.TargetRootDirectory + binaryOutputModuleInterfaceFile);
 				}
 
 				// Compile the individual translation units
@@ -191,7 +194,7 @@ namespace Soup.Build.Cpp.Compiler
 				TargetFile = targetFile,
 				TargetArchitecture = arguments.TargetArchitecture,
 				ImplementationFile = implementationFile,
-				RootDirectory = arguments.WorkingDirectory,
+				TargetRootDirectory = arguments.TargetRootDirectory,
 				LibraryPaths = arguments.LibraryPaths,
 				GenerateSourceDebugInfo = arguments.GenerateSourceDebugInfo,
 			};
@@ -214,7 +217,7 @@ namespace Soup.Build.Cpp.Compiler
 					
 					// Add the library as a link dependency and all recursive libraries
 					result.LinkDependencies = new List<Path>(arguments.LinkDependencies);
-					var absoluteTargetFile = linkArguments.TargetFile.HasRoot ? linkArguments.TargetFile : linkArguments.RootDirectory + linkArguments.TargetFile;
+					var absoluteTargetFile = linkArguments.TargetFile.HasRoot ? linkArguments.TargetFile : linkArguments.TargetRootDirectory + linkArguments.TargetFile;
 					result.LinkDependencies.Add(absoluteTargetFile);
 					break;
 				}
@@ -223,12 +226,12 @@ namespace Soup.Build.Cpp.Compiler
 					linkArguments.TargetType = LinkTarget.DynamicLibrary;
 
 					// Add the DLL as a runtime dependency
-					var absoluteTargetFile = linkArguments.TargetFile.HasRoot ? linkArguments.TargetFile : linkArguments.RootDirectory + linkArguments.TargetFile;
+					var absoluteTargetFile = linkArguments.TargetFile.HasRoot ? linkArguments.TargetFile : linkArguments.TargetRootDirectory + linkArguments.TargetFile;
 					result.RuntimeDependencies.Add(absoluteTargetFile);
 
 					// Clear out all previous link dependencies and replace with the 
 					// single implementation library for the DLL
-					var absoluteImplementationFile = linkArguments.ImplementationFile.HasRoot ? linkArguments.ImplementationFile : linkArguments.RootDirectory + linkArguments.ImplementationFile;
+					var absoluteImplementationFile = linkArguments.ImplementationFile.HasRoot ? linkArguments.ImplementationFile : linkArguments.TargetRootDirectory + linkArguments.ImplementationFile;
 					result.LinkDependencies.Add(absoluteImplementationFile);
 
 					// Set the targe file
@@ -241,7 +244,7 @@ namespace Soup.Build.Cpp.Compiler
 					linkArguments.TargetType = LinkTarget.Executable;
 
 					// Add the Executable as a runtime dependency
-					var absoluteTargetFile = linkArguments.TargetFile.HasRoot ? linkArguments.TargetFile : linkArguments.RootDirectory + linkArguments.TargetFile;
+					var absoluteTargetFile = linkArguments.TargetFile.HasRoot ? linkArguments.TargetFile : linkArguments.TargetRootDirectory + linkArguments.TargetFile;
 					result.RuntimeDependencies.Add(absoluteTargetFile);
 
 					// All link dependencies stop here.
@@ -300,7 +303,7 @@ namespace Soup.Build.Cpp.Compiler
 				{
 					var target = arguments.BinaryDirectory + new Path(source.GetFileName());
 					var operation = SharedOperations.CreateCopyFileOperation(
-						arguments.WorkingDirectory,
+						arguments.TargetRootDirectory,
 						source,
 						target);
 					result.BuildOperations.Add(operation);

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/CompileArguments.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/CompileArguments.cs
@@ -171,9 +171,14 @@ namespace Soup.Build.Cpp.Compiler
 		public OptimizationLevel Optimize { get; init; }
 
 		/// <summary>
-		/// Gets or sets the root directory
+		/// Gets or sets the source directory
 		/// </summary>
-		public Path RootDirectory { get; init; } = new Path();
+		public Path SourceRootDirectory { get; init; } = new Path();
+
+		/// <summary>
+		/// Gets or sets the target directory
+		/// </summary>
+		public Path TargetRootDirectory { get; init; } = new Path();
 
 		/// <summary>
 		/// Gets or sets the object directory
@@ -244,7 +249,8 @@ namespace Soup.Build.Cpp.Compiler
 			// Return true if the fields match.
 			return this.Standard == rhs.Standard &&
 				this.Optimize == rhs.Optimize &&
-				this.RootDirectory == rhs.RootDirectory &&
+				this.SourceRootDirectory == rhs.SourceRootDirectory &&
+				this.TargetRootDirectory == rhs.TargetRootDirectory &&
 				this.ObjectDirectory == rhs.ObjectDirectory &&
 				Enumerable.SequenceEqual(this.PreprocessorDefinitions, rhs.PreprocessorDefinitions) &&
 				Enumerable.SequenceEqual(this.IncludeDirectories, rhs.IncludeDirectories) &&
@@ -258,7 +264,7 @@ namespace Soup.Build.Cpp.Compiler
 				Enumerable.SequenceEqual(this.CustomProperties, rhs.CustomProperties);
 		}
 
-		public override int GetHashCode() => (Standard, Optimize, RootDirectory, ObjectDirectory, InterfaceUnit).GetHashCode();
+		public override int GetHashCode() => (Standard, Optimize, SourceRootDirectory, TargetRootDirectory, ObjectDirectory, InterfaceUnit).GetHashCode();
 
 		public static bool operator ==(SharedCompileArguments? lhs, SharedCompileArguments? rhs)
 		{
@@ -277,7 +283,7 @@ namespace Soup.Build.Cpp.Compiler
 
 		public override string ToString()
 		{
-			return $"SharedCompileArguments {{ Standard={Standard}, Optimize={Optimize}, RootDirectory=\"{RootDirectory}\", ObjectDirectory=\"{ObjectDirectory}\", PreprocessorDefinitions=[{string.Join(",", PreprocessorDefinitions)}], IncludeDirectories=[{string.Join(",", IncludeDirectories)}], IncludeModules=[{string.Join(",", IncludeModules)}], GenerateSourceDebugInfo=\"{GenerateSourceDebugInfo}\", InterfaceUnit={InterfaceUnit}, ImplementationUnits=[{string.Join(",", ImplementationUnits)}], EnableWarningsAsErrors=\"{EnableWarningsAsErrors}\", DisabledWarnings=[{string.Join(",", DisabledWarnings)}], EnabledWarnings=[{string.Join(",", EnabledWarnings)}], CustomProperties=[{string.Join(",", CustomProperties)}]}}";
+			return $"SharedCompileArguments {{ Standard={Standard}, Optimize={Optimize}, SourceRootDirectory=\"{SourceRootDirectory}\", TargetRootDirectory=\"{TargetRootDirectory}\", ObjectDirectory=\"{ObjectDirectory}\", PreprocessorDefinitions=[{string.Join(",", PreprocessorDefinitions)}], IncludeDirectories=[{string.Join(",", IncludeDirectories)}], IncludeModules=[{string.Join(",", IncludeModules)}], GenerateSourceDebugInfo=\"{GenerateSourceDebugInfo}\", InterfaceUnit={InterfaceUnit}, ImplementationUnits=[{string.Join(",", ImplementationUnits)}], EnableWarningsAsErrors=\"{EnableWarningsAsErrors}\", DisabledWarnings=[{string.Join(",", DisabledWarnings)}], EnabledWarnings=[{string.Join(",", EnabledWarnings)}], CustomProperties=[{string.Join(",", CustomProperties)}]}}";
 		}
 	}
 }

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/LinkArguments.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/LinkArguments.cs
@@ -53,7 +53,7 @@ namespace Soup.Build.Cpp.Compiler
 		/// <summary>
 		/// Gets or sets the root directory
 		/// </summary>
-		public Path RootDirectory { get; set; } = new Path();
+		public Path TargetRootDirectory { get; set; } = new Path();
 
 		/// <summary>
 		/// Gets or sets the target architecture
@@ -100,7 +100,7 @@ namespace Soup.Build.Cpp.Compiler
 			return this.TargetFile == rhs.TargetFile &&
 				this.TargetType == rhs.TargetType &&
 				this.ImplementationFile == rhs.ImplementationFile &&
-				this.RootDirectory == rhs.RootDirectory &&
+				this.TargetRootDirectory == rhs.TargetRootDirectory &&
 				this.TargetArchitecture == rhs.TargetArchitecture &&
 				Enumerable.SequenceEqual(this.ObjectFiles, rhs.ObjectFiles) &&
 				Enumerable.SequenceEqual(this.LibraryFiles, rhs.LibraryFiles) &&
@@ -109,7 +109,7 @@ namespace Soup.Build.Cpp.Compiler
 				this.GenerateSourceDebugInfo == rhs.GenerateSourceDebugInfo;
 		}
 
-		public override int GetHashCode() => (TargetFile, TargetType, ImplementationFile, RootDirectory, TargetArchitecture).GetHashCode();
+		public override int GetHashCode() => (TargetFile, TargetType, ImplementationFile, TargetRootDirectory, TargetArchitecture).GetHashCode();
 
 		public static bool operator ==(LinkArguments? lhs, LinkArguments? rhs)
 		{
@@ -128,7 +128,7 @@ namespace Soup.Build.Cpp.Compiler
 
         public override string ToString()
         {
-			return $"LinkArguments {{ TargetFile=\"{TargetFile}\", TargetType={TargetType}, ImplementationFile=\"{ImplementationFile}\", RootDirectory=\"{RootDirectory}\", TargetArchitecture=\"{TargetArchitecture}\", ObjectFiles=[{string.Join(",", ObjectFiles)}], LibraryFiles=[{string.Join(",", LibraryFiles)}], ExternalLibraryFiles=[{string.Join(",", ExternalLibraryFiles)}], LibraryPaths=[{string.Join(",", LibraryPaths)}], GenerateSourceDebugInfo={GenerateSourceDebugInfo} }}";
+			return $"LinkArguments {{ TargetFile=\"{TargetFile}\", TargetType={TargetType}, ImplementationFile=\"{ImplementationFile}\", TargetRootDirectory=\"{TargetRootDirectory}\", TargetArchitecture=\"{TargetArchitecture}\", ObjectFiles=[{string.Join(",", ObjectFiles)}], LibraryFiles=[{string.Join(",", LibraryFiles)}], ExternalLibraryFiles=[{string.Join(",", ExternalLibraryFiles)}], LibraryPaths=[{string.Join(",", LibraryPaths)}], GenerateSourceDebugInfo={GenerateSourceDebugInfo} }}";
 		}
     }
 }

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerArgumentBuilderUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerArgumentBuilderUnitTests.cs
@@ -387,6 +387,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 		[Fact]
 		public void BuildInterfaceUnitCompilerArguments()
 		{
+			var targetRootDirectory = new Path("C:/target/");
 			var arguments = new InterfaceUnitCompileArguments();
 			arguments.SourceFile = new Path("module.cpp");
 			arguments.TargetFile = new Path("module.obj");
@@ -395,6 +396,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			var responseFile = new Path("ResponseFile.txt");
 
 			var actualArguments = ArgumentBuilder.BuildInterfaceUnitCompilerArguments(
+				targetRootDirectory,
 				arguments,
 				responseFile);
 
@@ -402,10 +404,10 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			{
 				"@./ResponseFile.txt",
 				"./module.cpp",
-				"/Fo\"./module.obj\"",
+				"/Fo\"C:/target/module.obj\"",
 				"/interface",
 				"/ifcOutput",
-				"\"./module.ifc\"",
+				"\"C:/target/module.ifc\"",
 			};
 
 			Assert.Equal(expectedArguments, actualArguments);

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerArgumentBuilderUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerArgumentBuilderUnitTests.cs
@@ -414,6 +414,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 		[Fact]
 		public void BuildTranslationUnitCompilerArguments_Simple()
 		{
+			var targetRootDirectory = new Path("C:/target/");
 			var arguments = new TranslationUnitCompileArguments()
 			{
 				SourceFile = new Path("module.cpp"),
@@ -424,6 +425,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			var internalModules = new List<Path>();
 
 			var actualArguments = ArgumentBuilder.BuildTranslationUnitCompilerArguments(
+				targetRootDirectory,
 				arguments,
 				responseFile,
 				internalModules);
@@ -432,7 +434,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			{
 				"@./ResponseFile.txt",
 				"./module.cpp",
-				"/Fo\"./module.obj\"",
+				"/Fo\"C:/target/module.obj\"",
 			};
 
 			Assert.Equal(expectedArguments, actualArguments);
@@ -441,6 +443,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 		[Fact]
 		public void BuildTranslationUnitCompilerArguments_InternalModules()
 		{
+			var targetRootDirectory = new Path("C:/target/");
 			var arguments = new TranslationUnitCompileArguments()
 			{
 				SourceFile = new Path("module.cpp"),
@@ -455,6 +458,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			};
 
 			var actualArguments = ArgumentBuilder.BuildTranslationUnitCompilerArguments(
+				targetRootDirectory,
 				arguments,
 				responseFile,
 				internalModules);
@@ -467,7 +471,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 				"/reference",
 				"\"./Module2.ifc\"",
 				"./module.cpp",
-				"/Fo\"./module.obj\"",
+				"/Fo\"C:/target/module.obj\"",
 			};
 
 			Assert.Equal(expectedArguments, actualArguments);

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerUnitTests.cs
@@ -69,15 +69,15 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 					"./File.cpp",
 					new Path("C:/source/"),
 					new Path("C:/bin/mock.cl.exe"),
-					"@./ObjectDir/SharedCompileArguments.rsp ./File.cpp /Fo\"./obj/File.obj\"",
+					"@C:/target/ObjectDir/SharedCompileArguments.rsp ./File.cpp /Fo\"C:/target/obj/File.obj\"",
 					new List<Path>()
 					{
 						new Path("File.cpp"),
-						new Path("./ObjectDir/SharedCompileArguments.rsp"),
+						new Path("C:/target/ObjectDir/SharedCompileArguments.rsp"),
 					},
 					new List<Path>()
 					{
-						new Path("obj/File.obj"),
+						new Path("C:/target/obj/File.obj"),
 					}),
 				};
 
@@ -136,17 +136,17 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 					"./File.cpp",
 					new Path("C:/source/"),
 					new Path("C:/bin/mock.cl.exe"),
-					"@./ObjectDir/SharedCompileArguments.rsp ./File.cpp /Fo\"./obj/File.obj\" /interface /ifcOutput \"./obj/File.pcm\"",
+					"@C:/target/ObjectDir/SharedCompileArguments.rsp ./File.cpp /Fo\"./obj/File.obj\" /interface /ifcOutput \"./obj/File.pcm\"",
 					new List<Path>()
 					{
 						new Path("Module.pcm"),
 						new Path("File.cpp"),
-						new Path("./ObjectDir/SharedCompileArguments.rsp"),
+						new Path("C:/target/ObjectDir/SharedCompileArguments.rsp"),
 					},
 					new List<Path>()
 					{
-						new Path("obj/File.obj"),
-						new Path("obj/File.pcm"),
+						new Path("C:/target/obj/File.obj"),
+						new Path("C:/target/obj/File.pcm"),
 					}),
 				};
 
@@ -185,7 +185,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 				},
 				new List<Path>()
 				{
-					new Path("Library.mock.a"),
+					new Path("C:/target/Library.mock.a"),
 				});
 
 			Assert.Equal(expected, result);
@@ -228,7 +228,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 				},
 				new List<Path>()
 				{
-					new Path("Something.exe"),
+					new Path("C:/target/Something.exe"),
 				});
 
 			Assert.Equal(expected, result);

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerUnitTests.cs
@@ -34,7 +34,8 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 
 			var arguments = new SharedCompileArguments()
 			{
-				RootDirectory = new Path("Source/"),
+				SourceRootDirectory = new Path("C:/source/"),
+				TargetRootDirectory = new Path("C:/target/"),
 				ObjectDirectory = new Path("ObjectDir/"),
 			};
 
@@ -56,7 +57,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			{
 				new BuildOperation(
 					"WriteFile [./ObjectDir/SharedCompileArguments.rsp]",
-					new Path("Source/"),
+					new Path("C:/target/"),
 					new Path("./writefile.exe"),
 					"\"./ObjectDir/SharedCompileArguments.rsp\" \"/nologo /FC /permissive- /Zc:__cplusplus /Zc:externConstexpr /Zc:inline /Zc:throwingNew /W4 /std:c++11 /Od /X /RTC1 /EHsc /MT /bigobj /c\"",
 					new List<Path>(),
@@ -66,7 +67,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 					}),
 				new BuildOperation(
 					"./File.cpp",
-					new Path("Source/"),
+					new Path("C:/source/"),
 					new Path("C:/bin/mock.cl.exe"),
 					"@./ObjectDir/SharedCompileArguments.rsp ./File.cpp /Fo\"./obj/File.obj\"",
 					new List<Path>()
@@ -93,7 +94,8 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 
 			var arguments = new SharedCompileArguments()
 			{
-				RootDirectory = new Path("Source/"),
+				SourceRootDirectory = new Path("C:/source/"),
+				TargetRootDirectory = new Path("C:/target/"),
 				ObjectDirectory = new Path("ObjectDir/"),
 				IncludeDirectories = new List<Path>()
 				{
@@ -122,7 +124,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			{
 				new BuildOperation(
 					"WriteFile [./ObjectDir/SharedCompileArguments.rsp]",
-					new Path("Source/"),
+					new Path("C:/target/"),
 					new Path("./writefile.exe"),
 					"\"./ObjectDir/SharedCompileArguments.rsp\" \"/nologo /FC /permissive- /Zc:__cplusplus /Zc:externConstexpr /Zc:inline /Zc:throwingNew /W4 /std:c++11 /Od /I\"./Includes\" /DDEBUG /X /RTC1 /EHsc /MT /reference \"./Module.pcm\" /bigobj /c\"",
 					new List<Path>(),
@@ -132,7 +134,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 					}),
 				new BuildOperation(
 					"./File.cpp",
-					new Path("Source/"),
+					new Path("C:/source/"),
 					new Path("C:/bin/mock.cl.exe"),
 					"@./ObjectDir/SharedCompileArguments.rsp ./File.cpp /Fo\"./obj/File.obj\" /interface /ifcOutput \"./obj/File.pcm\"",
 					new List<Path>()
@@ -163,7 +165,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			arguments.TargetType = LinkTarget.StaticLibrary;
 			arguments.TargetArchitecture = "x64";
 			arguments.TargetFile = new Path("Library.mock.a");
-			arguments.RootDirectory = new Path("Source/");
+			arguments.TargetRootDirectory = new Path("C:/target/");
 			arguments.ObjectFiles = new List<Path>()
 			{
 				new Path("File.mock.obj"),
@@ -174,7 +176,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			// Verify result
 			var expected = new BuildOperation(
 				"./Library.mock.a",
-				new Path("Source/"),
+				new Path("C:/target/"),
 				new Path("C:/bin/mock.lib.exe"),
 				"/nologo /machine:X64 /out:\"./Library.mock.a\" ./File.mock.obj",
 				new List<Path>()
@@ -201,7 +203,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			arguments.TargetType = LinkTarget.Executable;
 			arguments.TargetArchitecture = "x64";
 			arguments.TargetFile = new Path("Something.exe");
-			arguments.RootDirectory = new Path("Source/");
+			arguments.TargetRootDirectory = new Path("C:/target/");
 			arguments.ObjectFiles = new List<Path>()
 			{
 				new Path("File.mock.obj"),
@@ -216,7 +218,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			// Verify result
 			var expected = new BuildOperation(
 				"./Something.exe",
-				new Path("Source/"),
+				new Path("C:/target/"),
 				new Path("C:/bin/mock.link.exe"),
 				"/nologo /subsystem:console /machine:X64 /out:\"./Something.exe\" ./Library.mock.a ./File.mock.obj",
 				new List<Path>()

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerUnitTests.cs
@@ -136,7 +136,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 					"./File.cpp",
 					new Path("C:/source/"),
 					new Path("C:/bin/mock.cl.exe"),
-					"@C:/target/ObjectDir/SharedCompileArguments.rsp ./File.cpp /Fo\"./obj/File.obj\" /interface /ifcOutput \"./obj/File.pcm\"",
+					"@C:/target/ObjectDir/SharedCompileArguments.rsp ./File.cpp /Fo\"C:/target/obj/File.obj\" /interface /ifcOutput \"C:/target/obj/File.pcm\"",
 					new List<Path>()
 					{
 						new Path("Module.pcm"),

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/ArgumentBuilder.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/ArgumentBuilder.cs
@@ -193,6 +193,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 		}
 
 		public static IList<string> BuildInterfaceUnitCompilerArguments(
+			Path targetRootDirectory,
 			InterfaceUnitCompileArguments arguments,
 			Path responseFile)
 		{
@@ -206,17 +207,20 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 			commandArguments.Add(arguments.SourceFile.ToString());
 
 			// Add the target file as outputs
+			var absoluteTargetFile = targetRootDirectory + arguments.TargetFile;
 			AddFlagValueWithQuotes(
 				commandArguments,
 				Compiler_ArgumentParameter_ObjectFile,
-				arguments.TargetFile.ToString());
+				absoluteTargetFile.ToString());
 
 			// Add the unique arguments for an interface unit
 			AddFlag(commandArguments, "interface");
 
 			// Specify the module interface file output
 			AddFlag(commandArguments, "ifcOutput");
-			AddValueWithQuotes(commandArguments, arguments.ModuleInterfaceTarget.ToString());
+
+			var absoluteModuleInterfaceFile = targetRootDirectory + arguments.ModuleInterfaceTarget;
+			AddValueWithQuotes(commandArguments, absoluteModuleInterfaceFile.ToString());
 
 			return commandArguments;
 		}

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/ArgumentBuilder.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/ArgumentBuilder.cs
@@ -206,7 +206,10 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 			commandArguments.Add(arguments.SourceFile.ToString());
 
 			// Add the target file as outputs
-			AddFlagValueWithQuotes(commandArguments, Compiler_ArgumentParameter_ObjectFile, arguments.TargetFile.ToString());
+			AddFlagValueWithQuotes(
+				commandArguments,
+				Compiler_ArgumentParameter_ObjectFile,
+				arguments.TargetFile.ToString());
 
 			// Add the unique arguments for an interface unit
 			AddFlag(commandArguments, "interface");
@@ -219,6 +222,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 		}
 
 		public static IList<string> BuildTranslationUnitCompilerArguments(
+			Path targetRootDirectory,
 			TranslationUnitCompileArguments arguments,
 			Path responseFile,
 			IList<Path> internalModules)
@@ -240,7 +244,11 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 			commandArguments.Add(arguments.SourceFile.ToString());
 
 			// Add the target file as outputs
-			AddFlagValueWithQuotes(commandArguments, Compiler_ArgumentParameter_ObjectFile, arguments.TargetFile.ToString());
+			var absoluteTargetFile = targetRootDirectory + arguments.TargetFile;
+			AddFlagValueWithQuotes(
+				commandArguments,
+				Compiler_ArgumentParameter_ObjectFile,
+				absoluteTargetFile.ToString());
 
 			return commandArguments;
 		}

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/Compiler.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/Compiler.cs
@@ -88,6 +88,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 
 				// Build the unique arguments for this translation unit
 				var commandArguments = ArgumentBuilder.BuildInterfaceUnitCompilerArguments(
+					arguments.TargetRootDirectory,
 					interfaceUnitArguments,
 					absoluteResponseFile);
 
@@ -102,7 +103,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 				operations.Add(buildOperation);
 
 				// Add our module interface back in for the downstream compilers
-				internalModules.Add(interfaceUnitArguments.ModuleInterfaceTarget);
+				internalModules.Add(arguments.TargetRootDirectory + interfaceUnitArguments.ModuleInterfaceTarget);
 			}
 
 			foreach (var implementationUnitArguments in arguments.ImplementationUnits)

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/Compiler.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/Compiler.cs
@@ -68,6 +68,8 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 			// Initialize a shared input set
 			var sharedInputFiles = arguments.IncludeModules;
 
+			var absoluteResponseFile = arguments.TargetRootDirectory + responseFile;
+
 			// Generate the interface build operation if present
 			var internalModules = new List<Path>();
 			if (arguments.InterfaceUnit is not null)
@@ -77,17 +79,17 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 				// Build up the input/output sets
 				var inputFiles = sharedInputFiles.ToList();
 				inputFiles.Add(interfaceUnitArguments.SourceFile);
-				inputFiles.Add(responseFile);
+				inputFiles.Add(absoluteResponseFile);
 				var outputFiles = new List<Path>()
 				{
-					interfaceUnitArguments.TargetFile,
-					interfaceUnitArguments.ModuleInterfaceTarget,
+					arguments.TargetRootDirectory + interfaceUnitArguments.TargetFile,
+					arguments.TargetRootDirectory + interfaceUnitArguments.ModuleInterfaceTarget,
 				};
 
 				// Build the unique arguments for this translation unit
 				var commandArguments = ArgumentBuilder.BuildInterfaceUnitCompilerArguments(
 					interfaceUnitArguments,
-					responseFile);
+					absoluteResponseFile);
 
 				// Generate the operation
 				var buildOperation = new BuildOperation(
@@ -108,16 +110,17 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 				// Build up the input/output sets
 				var inputFiles = sharedInputFiles.ToList();
 				inputFiles.Add(implementationUnitArguments.SourceFile);
-				inputFiles.Add(responseFile);
+				inputFiles.Add(absoluteResponseFile);
 				var outputFiles = new List<Path>()
 				{
-					implementationUnitArguments.TargetFile,
+					arguments.TargetRootDirectory + implementationUnitArguments.TargetFile,
 				};
 
 				// Build the unique arguments for this translation unit
 				var commandArguments = ArgumentBuilder.BuildTranslationUnitCompilerArguments(
+					arguments.TargetRootDirectory,
 					implementationUnitArguments,
-					responseFile,
+					absoluteResponseFile,
 					internalModules);
 
 				// Generate the operation
@@ -161,7 +164,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 			inputFiles.AddRange(arguments.ObjectFiles);
 			var outputFiles = new List<Path>()
 			{
-				arguments.TargetFile,
+				arguments.TargetRootDirectory + arguments.TargetFile,
 			};
 			var commandarguments = ArgumentBuilder.BuildLinkerArguments(arguments);
 

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/Compiler.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/Compiler.cs
@@ -60,7 +60,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 			var responseFile = arguments.ObjectDirectory + new Path("SharedCompileArguments.rsp");
 			var sharedCommandArguments = ArgumentBuilder.BuildSharedCompilerArguments(arguments);
 			var writeSharedArgumentsOperation = SharedOperations.CreateWriteFileOperation(
-				arguments.RootDirectory,
+				arguments.TargetRootDirectory,
 				responseFile,
 				CombineArguments(sharedCommandArguments));
 			operations.Add(writeSharedArgumentsOperation);
@@ -92,7 +92,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 				// Generate the operation
 				var buildOperation = new BuildOperation(
 					interfaceUnitArguments.SourceFile.ToString(),
-					arguments.RootDirectory,
+					arguments.SourceRootDirectory,
 					_compilerExecutable,
 					CombineArguments(commandArguments),
 					inputFiles,
@@ -123,7 +123,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 				// Generate the operation
 				var buildOperation = new BuildOperation(
 					implementationUnitArguments.SourceFile.ToString(),
-					arguments.RootDirectory,
+					arguments.SourceRootDirectory,
 					_compilerExecutable,
 					CombineArguments(commandArguments),
 					inputFiles.ToArray(),
@@ -167,7 +167,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 
 			var buildOperation = new BuildOperation(
 				arguments.TargetFile.ToString(),
-				arguments.RootDirectory,
+				arguments.TargetRootDirectory,
 				executablePath,
 				CombineArguments(commandarguments),
 				inputFiles,

--- a/Source/GenerateSharp/Extensions/Cpp/Extension.UnitTests/Tasks/BuildTaskUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension.UnitTests/Tasks/BuildTaskUnitTests.cs
@@ -50,7 +50,8 @@ namespace Soup.Build.Cpp.UnitTests
 				buildTable.Add("TargetName", new Value("Program"));
 				buildTable.Add("TargetType", new Value((long)BuildTargetType.Executable));
 				buildTable.Add("LanguageStandard", new Value((long)LanguageStandard.CPP20));
-				buildTable.Add("WorkingDirectory", new Value("C:/root/"));
+				buildTable.Add("SourceRootDirectory", new Value("C:/source/"));
+				buildTable.Add("TargetRootDirectory", new Value("C:/target/"));
 				buildTable.Add("ObjectDirectory", new Value("obj/"));
 				buildTable.Add("BinaryDirectory", new Value("bin/"));
 				buildTable.Add(
@@ -101,7 +102,8 @@ namespace Soup.Build.Cpp.UnitTests
 				{
 					Standard = LanguageStandard.CPP20,
 					Optimize = OptimizationLevel.None,
-					RootDirectory = new Path("C:/root/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
 					ObjectDirectory = new Path("obj/"),
 				};
 
@@ -118,7 +120,7 @@ namespace Soup.Build.Cpp.UnitTests
 				expectedLinkArguments.TargetType = LinkTarget.Executable;
 				expectedLinkArguments.TargetArchitecture = "x64";
 				expectedLinkArguments.TargetFile = new Path("bin/Program.exe");
-				expectedLinkArguments.RootDirectory = new Path("C:/root/");
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
 				expectedLinkArguments.ObjectFiles = new List<Path>()
 				{
 					new Path("obj/TestFile.mock.obj"),
@@ -143,7 +145,7 @@ namespace Soup.Build.Cpp.UnitTests
 				{
 					new BuildOperation(
 						"MakeDir [./obj/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./obj/\"",
 						new List<Path>(),
@@ -153,7 +155,7 @@ namespace Soup.Build.Cpp.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/\"",
 						new List<Path>(),
@@ -216,7 +218,8 @@ namespace Soup.Build.Cpp.UnitTests
 				buildTable.Add("TargetName", new Value("Library"));
 				buildTable.Add("TargetType", new Value((long)BuildTargetType.StaticLibrary));
 				buildTable.Add("LanguageStandard", new Value((long)LanguageStandard.CPP20));
-				buildTable.Add("WorkingDirectory", new Value("C:/root/"));
+				buildTable.Add("SourceRootDirectory", new Value("C:/source/"));
+				buildTable.Add("TargetRootDirectory", new Value("C:/target/"));
 				buildTable.Add("ObjectDirectory", new Value("obj/"));
 				buildTable.Add("BinaryDirectory", new Value("bin/"));
 				buildTable.Add("Source", new Value(new ValueList()
@@ -281,7 +284,8 @@ namespace Soup.Build.Cpp.UnitTests
 				{
 					Standard = LanguageStandard.CPP20,
 					Optimize = OptimizationLevel.None,
-					RootDirectory = new Path("C:/root/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
 					ObjectDirectory = new Path("obj/"),
 					IncludeDirectories = new List<Path>()
 					{
@@ -318,7 +322,7 @@ namespace Soup.Build.Cpp.UnitTests
 				expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
 				expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
 				expectedLinkArguments.TargetArchitecture = "x64";
-				expectedLinkArguments.RootDirectory = new Path("C:/root/");
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
 				expectedLinkArguments.ObjectFiles = new List<Path>()
 				{
 					new Path("obj/TestFile1.mock.obj"),
@@ -346,7 +350,7 @@ namespace Soup.Build.Cpp.UnitTests
 				{
 					new BuildOperation(
 						"MakeDir [./obj/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./obj/\"",
 						new List<Path>(),
@@ -356,7 +360,7 @@ namespace Soup.Build.Cpp.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/\"",
 						new List<Path>(),
@@ -445,7 +449,8 @@ namespace Soup.Build.Cpp.UnitTests
 				buildTable.Add("TargetName", new Value("Library"));
 				buildTable.Add("TargetType", new Value((long)BuildTargetType.StaticLibrary));
 				buildTable.Add("LanguageStandard", new Value((long)LanguageStandard.CPP20));
-				buildTable.Add("WorkingDirectory", new Value("C:/root/"));
+				buildTable.Add("SourceRootDirectory", new Value("C:/source/"));
+				buildTable.Add("TargetRootDirectory", new Value("C:/target/"));
 				buildTable.Add("ObjectDirectory", new Value("obj/"));
 				buildTable.Add("BinaryDirectory", new Value("bin/"));
 				buildTable.Add("ModuleInterfaceSourceFile", new Value("Public.cpp"));
@@ -518,7 +523,8 @@ namespace Soup.Build.Cpp.UnitTests
 				{
 					Standard = LanguageStandard.CPP20,
 					Optimize = OptimizationLevel.None,
-					RootDirectory = new Path("C:/root/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
 					ObjectDirectory = new Path("obj/"),
 					IncludeDirectories = new List<Path>()
 					{
@@ -565,7 +571,7 @@ namespace Soup.Build.Cpp.UnitTests
 				expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
 				expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
 				expectedLinkArguments.TargetArchitecture = "x64";
-				expectedLinkArguments.RootDirectory = new Path("C:/root/");
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
 				expectedLinkArguments.ObjectFiles = new List<Path>()
 				{
 					new Path("obj/TestFile1.mock.obj"),
@@ -594,7 +600,7 @@ namespace Soup.Build.Cpp.UnitTests
 				{
 					new BuildOperation(
 						"MakeDir [./obj/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./obj/\"",
 						new List<Path>(),
@@ -604,7 +610,7 @@ namespace Soup.Build.Cpp.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/\"",
 						new List<Path>(),
@@ -614,7 +620,7 @@ namespace Soup.Build.Cpp.UnitTests
 						}),
 					new BuildOperation(
 						"Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/copy.exe"),
 						"\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
 						new List<Path>()
@@ -719,7 +725,8 @@ namespace Soup.Build.Cpp.UnitTests
 				buildTable.Add("TargetName", new Value("Library"));
 				buildTable.Add("TargetType", new Value((long)BuildTargetType.StaticLibrary));
 				buildTable.Add("LanguageStandard", new Value((long)LanguageStandard.CPP20));
-				buildTable.Add("WorkingDirectory", new Value("C:/root/"));
+				buildTable.Add("SourceRootDirectory", new Value("C:/source/"));
+				buildTable.Add("TargetRootDirectory", new Value("C:/target/"));
 				buildTable.Add("ObjectDirectory", new Value("obj/"));
 				buildTable.Add("BinaryDirectory", new Value("bin/"));
 				buildTable.Add("ModuleInterfaceSourceFile", new Value("Public.cpp"));
@@ -784,7 +791,8 @@ namespace Soup.Build.Cpp.UnitTests
 				{
 					Standard = LanguageStandard.CPP20,
 					Optimize = OptimizationLevel.None,
-					RootDirectory = new Path("C:/root/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
 					ObjectDirectory = new Path("./obj/"),
 					IncludeDirectories = new List<Path>()
 					{
@@ -813,7 +821,7 @@ namespace Soup.Build.Cpp.UnitTests
 				expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
 				expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
 				expectedLinkArguments.TargetArchitecture = "x64";
-				expectedLinkArguments.RootDirectory = new Path("C:/root/");
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
 				expectedLinkArguments.ObjectFiles = new List<Path>()
 				{
 					new Path("obj/Public.mock.obj"),
@@ -839,7 +847,7 @@ namespace Soup.Build.Cpp.UnitTests
 				{
 					new BuildOperation(
 						"MakeDir [./obj/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./obj/\"",
 						new List<Path>(),
@@ -849,7 +857,7 @@ namespace Soup.Build.Cpp.UnitTests
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/mkdir.exe"),
 						"\"./bin/\"",
 						new List<Path>(),
@@ -859,7 +867,7 @@ namespace Soup.Build.Cpp.UnitTests
 						}),
 					new BuildOperation(
 						"Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
-						new Path("C:/root/"),
+						new Path("C:/target/"),
 						new Path("C:/copy.exe"),
 						"\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
 						new List<Path>()

--- a/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/BuildTask.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/BuildTask.cs
@@ -70,7 +70,8 @@ namespace Soup.Build.Cpp
 				buildTable["TargetType"].AsInteger();
 			arguments.LanguageStandard = (LanguageStandard)
 				buildTable["LanguageStandard"].AsInteger();
-			arguments.WorkingDirectory = new Path(buildTable["WorkingDirectory"].AsString());
+			arguments.SourceRootDirectory = new Path(buildTable["SourceRootDirectory"].AsString());
+			arguments.TargetRootDirectory = new Path(buildTable["TargetRootDirectory"].AsString());
 			arguments.ObjectDirectory = new Path(buildTable["ObjectDirectory"].AsString());
 			arguments.BinaryDirectory = new Path(buildTable["BinaryDirectory"].AsString());
 

--- a/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/RecipeBuildTask.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/RecipeBuildTask.cs
@@ -142,8 +142,8 @@ namespace Soup.Build.Cpp
 
             // Build up arguments to build this individual recipe
             var targetDirectory = new Path(parametersTable["TargetDirectory"].AsString());
-            var binaryDirectory = targetDirectory + new Path("bin/");
-            var objectDirectory = targetDirectory + new Path("obj/");
+            var binaryDirectory = new Path("bin/");
+            var objectDirectory = new Path("obj/");
 
             // Load the module interface file if present
             var moduleInterfaceSourceFile = string.Empty;

--- a/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/RecipeBuildTask.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/RecipeBuildTask.cs
@@ -200,7 +200,8 @@ namespace Soup.Build.Cpp
             }
 
             buildTable["TargetName"] = this.factory.Create(name);
-            buildTable["WorkingDirectory"] = this.factory.Create(packageRoot.ToString());
+            buildTable["SourceRootDirectory"] = this.factory.Create(packageRoot.ToString());
+            buildTable["TargetRootDirectory"] = this.factory.Create(targetDirectory.ToString());
             buildTable["ObjectDirectory"] = this.factory.Create(objectDirectory.ToString());
             buildTable["BinaryDirectory"] = this.factory.Create(binaryDirectory.ToString());
             buildTable["ModuleInterfaceSourceFile"] = this.factory.Create(moduleInterfaceSourceFile);

--- a/Source/GenerateSharp/Generate/Contracts/ValueTableReader.cs
+++ b/Source/GenerateSharp/Generate/Contracts/ValueTableReader.cs
@@ -47,7 +47,8 @@ namespace Soup.Build.Generate
 
 			if (reader.BaseStream.Position != reader.BaseStream.Length)
 			{
-				throw new InvalidOperationException("Value Table file corrupted - Did not read the entire file");
+				var remaining = reader.BaseStream.Length - reader.BaseStream.Position;
+				throw new InvalidOperationException($"Value Table file corrupted - Did not read the entire file {remaining}");
 			}
 
 			return rootTable;

--- a/Source/GenerateSharp/Generate/OperationGraph/OperationGraphReader.cs
+++ b/Source/GenerateSharp/Generate/OperationGraph/OperationGraphReader.cs
@@ -88,7 +88,8 @@ namespace Soup.Build.Generate
 
 			if (reader.BaseStream.Position != reader.BaseStream.Length)
 			{
-				throw new InvalidOperationException("Operation graph file corrupted - Did not read the entire file");
+				var remaining = reader.BaseStream.Length - reader.BaseStream.Position;
+				throw new InvalidOperationException($"Operation graph file corrupted - Did not read the entire file {remaining}");
 			}
 
 			return new OperationGraph(

--- a/Source/GenerateSharp/Runtime.UnitTests/Utilities/OperationGraphGeneratorUnitTests.cs
+++ b/Source/GenerateSharp/Runtime.UnitTests/Utilities/OperationGraphGeneratorUnitTests.cs
@@ -35,6 +35,7 @@ namespace Soup.Build.Runtime.UnitTests
 			Assert.Equal(
 				new List<string>()
 				{
+					"DIAG: Create Operation: Do Stuff",
 					"DIAG: Read Access Subset:",
 					"DIAG: Write Access Subset:",
 				},
@@ -182,7 +183,7 @@ namespace Soup.Build.Runtime.UnitTests
 			Assert.Equal(
 				new List<string>()
 				{
-					"DIAG: Allow C:/WorkingDir/ReadAccess/ : C:/WorkingDir/ReadAccess/ReadFile.txt",
+					"DIAG: Create Operation: Do Stuff",
 					"DIAG: Read Access Subset:",
 					"DIAG: C:/WorkingDir/ReadAccess/",
 					"DIAG: Write Access Subset:"
@@ -223,8 +224,8 @@ namespace Soup.Build.Runtime.UnitTests
 			Assert.Equal(
 				new List<string>()
 				{
+					"DIAG: Create Operation: Do Stuff",
 					"DIAG: Read Access Subset:",
-					"DIAG: Allow C:/WorkingDir/WriteAccess/ : C:/WorkingDir/WriteAccess/WriteFile.txt",
 					"DIAG: Write Access Subset:",
 					"DIAG: C:/WorkingDir/WriteAccess/",
 				},
@@ -264,7 +265,7 @@ namespace Soup.Build.Runtime.UnitTests
 			Assert.Equal(
 				new List<string>()
 				{
-					"DIAG: Allow C:/WorkingDir/ReadAccess/ : C:/WorkingDir/ReadAccess/SubFolder/ReadFile.txt",
+					"DIAG: Create Operation: Do Stuff",
 					"DIAG: Read Access Subset:",
 					"DIAG: C:/WorkingDir/ReadAccess/",
 					"DIAG: Write Access Subset:"
@@ -305,8 +306,8 @@ namespace Soup.Build.Runtime.UnitTests
 			Assert.Equal(
 				new List<string>()
 				{
+					"DIAG: Create Operation: Do Stuff",
 					"DIAG: Read Access Subset:",
-					"DIAG: Allow C:/WorkingDir/WriteAccess/ : C:/WorkingDir/WriteAccess/SubFolder/WriteFile.txt",
 					"DIAG: Write Access Subset:",
 					"DIAG: C:/WorkingDir/WriteAccess/",
 				},

--- a/Source/GenerateSharp/Runtime/OperationGraph/OperationGraphGenerator.cs
+++ b/Source/GenerateSharp/Runtime/OperationGraph/OperationGraphGenerator.cs
@@ -50,6 +50,8 @@ namespace Soup.Build.Runtime
 			List<Path> declaredInput,
 			List<Path> declaredOutput)
 		{
+			Log.Diag($"Create Operation: {title}");
+
 			if (!workingDirectory.HasRoot)
 				throw new InvalidOperationException("Working directory must be an absolute path.");
 
@@ -230,7 +232,6 @@ namespace Soup.Build.Runtime
 			{
 				if (fileString.StartsWith(accessDirectory.ToString()))
 				{
-					Log.Diag($"Allow {accessDirectory} : {fileString}");
 					return accessDirectory;
 				}
 			}

--- a/Source/Installer/SoupInstaller/App.config
+++ b/Source/Installer/SoupInstaller/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/Source/Installer/SoupInstaller/Setup.cs
+++ b/Source/Installer/SoupInstaller/Setup.cs
@@ -67,7 +67,7 @@ class Script
         };
 
         // Upgrade values
-        project.Version = new Version(0, 15, 0);
+        project.Version = new Version(0, 15, 1);
 
         Compiler.BuildMsi(project);
     }

--- a/Source/Installer/SoupInstaller/SoupInstaller.csproj
+++ b/Source/Installer/SoupInstaller/SoupInstaller.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>SoupInstaller</RootNamespace>
     <AssemblyName>SoupInstaller</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -34,6 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BootstrapperCore, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">


### PR DESCRIPTION
This change aims to use relative paths for as much reporting as possible to cleanup the operation titles.