### PR TITLE
Add support for partition unit builds

### DIFF
--- a/Source/Client/CLI/Recipe.toml
+++ b/Source/Client/CLI/Recipe.toml
@@ -1,6 +1,6 @@
 Name = "Soup"
 Language = "C++"
-Version = "0.17.1"
+Version = "0.17.2"
 Type = "Executable"
 
 Source = [

--- a/Source/Client/CLI/Source/Commands/VersionCommand.h
+++ b/Source/Client/CLI/Source/Commands/VersionCommand.h
@@ -31,7 +31,7 @@ namespace Soup::Client
 
 			// TODO var version = Assembly.GetExecutingAssembly().GetName().Version;
 			// Log::Message($"{version.Major}.{version.Minor}.{version.Build}");
-			Log::HighPriority("0.17.1");
+			Log::HighPriority("0.17.2");
 		}
 
 	private:

--- a/Source/GenerateSharp/Extensions/CSharp/Extension/PackageLock.toml
+++ b/Source/GenerateSharp/Extensions/CSharp/Extension/PackageLock.toml
@@ -2,8 +2,8 @@
 "C#" = [
 	{ Name = "Soup.CSharp", Version = "./" },
 	{ Name = "Opal", Version = "Opal@1.0.1" },
-	{ Name = "Soup.Build", Version = "Soup.Build@0.1.3" },
-	{ Name = "Soup.Build.Extensions", Version = "Soup.Build.Extensions@0.1.8" },
-	{ Name = "Soup.CSharp.Compiler", Version = "Soup.CSharp.Compiler@0.1.5" },
-	{ Name = "Soup.CSharp.Compiler.Roslyn", Version = "Soup.CSharp.Compiler.Roslyn@0.1.6" },
+	{ Name = "Soup.Build", Version = "../../../Build/" },
+	{ Name = "Soup.Build.Extensions", Version = "../../../Build.Extensions/" },
+	{ Name = "Soup.CSharp.Compiler", Version = "../Compiler/Core/" },
+	{ Name = "Soup.CSharp.Compiler.Roslyn", Version = "../Compiler/Roslyn/" },
 ]

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
@@ -1432,6 +1432,8 @@ namespace Soup.Build.Cpp.Compiler.UnitTests
 				Assert.Equal(
 					new List<Path>()
 					{
+						new Path("C:/target/obj/TestFile1.mock.bmi"),
+						new Path("C:/target/obj/TestFile2.mock.bmi"),
 						new Path("C:/target/bin/Library.mock.bmi"),
 					},
 					result.ModuleDependencies);

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
@@ -7,1322 +7,1655 @@ using Xunit;
 
 namespace Soup.Build.Cpp.Compiler.UnitTests
 {
-    public class BuildEngineUnitTests
-    {
-        [Fact]
-        public void Initialize_Success()
-        {
-            var compiler = new Mock.Compiler();
-            var uut = new BuildEngine(compiler);
-        }
-
-        [Fact]
-        public void Build_WindowsApplication()
-        {
-            // Register the test process manager
-            var processManager = new MockProcessManager();
-
-            // Register the test listener
-            var testListener = new TestTraceListener();
-            using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
-            using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
-            {
-                // Register the mock compiler
-                var compiler = new Mock.Compiler();
-
-                // Register the test process manager
-
-                // Setup the build arguments
-                var arguments = new BuildArguments();
-                arguments.TargetName = "Program";
-                arguments.TargetType = BuildTargetType.WindowsApplication;
-                arguments.LanguageStandard = LanguageStandard.CPP20;
-                arguments.SourceRootDirectory = new Path("C:/source/");
-                arguments.TargetRootDirectory = new Path("C:/target/");
-                arguments.ObjectDirectory = new Path("obj/");
-                arguments.BinaryDirectory = new Path("bin/");
-                arguments.SourceFiles = new List<Path>()
-                {
-                    new Path("TestFile.cpp"),
-                };
-                arguments.OptimizationLevel = BuildOptimizationLevel.None;
-                arguments.LinkDependencies = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.a"),
-                    new Path("../OtherModule2.mock.a"),
-                };
-
-                var uut = new BuildEngine(compiler);
-                var fileSystemState = new FileSystemState();
-                var readAccessList = new List<Path>();
-                var writeAccessList = new List<Path>();
-                var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
-                var result = uut.Execute(buildState, arguments);
-
-                // Verify expected process manager requests
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "GetCurrentProcessFileName",
-                        "GetCurrentProcessFileName",
-                    },
-                    processManager.GetRequests());
-
-                // Verify expected logs
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "INFO: Generate Compile Operation: ./TestFile.cpp",
-                        "INFO: CoreLink",
-                        "INFO: Linking target",
-                        "INFO: Generate Link Operation: ./bin/Program.exe",
-                    },
-                    testListener.GetMessages());
-
-                var expectedCompileArguments = new SharedCompileArguments()
-                {
-                    Standard = LanguageStandard.CPP20,
-                    Optimize = OptimizationLevel.None,
-                    ObjectDirectory = new Path("obj/"),
-                    SourceRootDirectory = new Path("C:/source/"),
-                    TargetRootDirectory = new Path("C:/target/"),
-                };
-
-                var expectedTranslationUnitArguments = new TranslationUnitCompileArguments()
-                {
-                    SourceFile = new Path("TestFile.cpp"),
-                    TargetFile = new Path("obj/TestFile.mock.obj"),
-                };
-                expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
-                {
-                    expectedTranslationUnitArguments,
-                };
-
-                var expectedLinkArguments = new LinkArguments();
-                expectedLinkArguments.TargetType = LinkTarget.WindowsApplication;
-                expectedLinkArguments.TargetFile = new Path("bin/Program.exe");
-                expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
-                expectedLinkArguments.ObjectFiles = new List<Path>()
-                {
-                    new Path("obj/TestFile.mock.obj"),
-                };
-                expectedLinkArguments.LibraryFiles = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.a"),
-                    new Path("../OtherModule2.mock.a"),
-                };
-
-                // Verify expected compiler calls
-                Assert.Equal(
-                    new List<SharedCompileArguments>()
-                    {
-                        expectedCompileArguments,
-                    },
-                    compiler.GetCompileRequests());
-                Assert.Equal(
-                    new List<LinkArguments>()
-                    {
-                        expectedLinkArguments,
-                    },
-                    compiler.GetLinkRequests());
-
-                var expectedBuildOperations = new List<BuildOperation>()
-                {
-                    new BuildOperation(
-                        "MakeDir [./obj/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./obj/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./obj/"),
-                        }),
-                    new BuildOperation(
-                        "MakeDir [./bin/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./bin/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./bin/"),
-                        }),
-                    new BuildOperation(
-                        "MockCompile: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("TestFile.cpp"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("obj/TestFile.mock.obj"),
-                        }),
-                    new BuildOperation(
-                        "MockLink: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockLinker.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("InputFile.in"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("OutputFile.out"),
-                        }),
-                };
-
-                Assert.Equal(
-                    expectedBuildOperations,
-                    result.BuildOperations);
-
-                Assert.Equal(
-                    new List<Path>(),
-                    result.ModuleDependencies);
-
-                Assert.Equal(
-                    new List<Path>(),
-                    result.LinkDependencies);
-
-                Assert.Equal(
-                    new List<Path>()
-                    {
-                        new Path("C:/target/bin/Program.exe"),
-                    },
-                    result.RuntimeDependencies);
-            }
-        }
-
-        [Fact]
-        public void Build_WindowsApplicationWithResource()
-        {
-            // Register the test process manager
-            var processManager = new MockProcessManager();
-
-            // Register the test listener
-            var testListener = new TestTraceListener();
-            using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
-            using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
-            {
-                // Register the mock compiler
-                var compiler = new Mock.Compiler();
-
-                // Register the test process manager
-
-                // Setup the build arguments
-                var arguments = new BuildArguments();
-                arguments.TargetName = "Program";
-                arguments.TargetType = BuildTargetType.WindowsApplication;
-                arguments.LanguageStandard = LanguageStandard.CPP20;
-                arguments.SourceRootDirectory = new Path("C:/source/");
-                arguments.TargetRootDirectory = new Path("C:/target/");
-                arguments.ObjectDirectory = new Path("obj/");
-                arguments.BinaryDirectory = new Path("bin/");
-                arguments.SourceFiles = new List<Path>()
-                {
-                    new Path("TestFile.cpp"),
-                };
-                arguments.ResourceFile = new Path("Resources.rc");
-                arguments.OptimizationLevel = BuildOptimizationLevel.None;
-                arguments.LinkDependencies = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.a"),
-                    new Path("../OtherModule2.mock.a"),
-                };
-
-                var uut = new BuildEngine(compiler);
-                var fileSystemState = new FileSystemState();
-                var readAccessList = new List<Path>();
-                var writeAccessList = new List<Path>();
-                var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
-                var result = uut.Execute(buildState, arguments);
-
-                // Verify expected process manager requests
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "GetCurrentProcessFileName",
-                        "GetCurrentProcessFileName",
-                    },
-                    processManager.GetRequests());
-
-                // Verify expected logs
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "INFO: Generate Resource File Compile: ./Resources.rc",
-                        "INFO: Generate Compile Operation: ./TestFile.cpp",
-                        "INFO: CoreLink",
-                        "INFO: Linking target",
-                        "INFO: Generate Link Operation: ./bin/Program.exe",
-                    },
-                    testListener.GetMessages());
-
-                var expectedCompileArguments = new SharedCompileArguments()
-                {
-                    Standard = LanguageStandard.CPP20,
-                    Optimize = OptimizationLevel.None,
-                    ObjectDirectory = new Path("obj/"),
-                    SourceRootDirectory = new Path("C:/source/"),
-                    TargetRootDirectory = new Path("C:/target/"),
-                };
-
-                var expectedTranslationUnitArguments = new TranslationUnitCompileArguments()
-                {
-                    SourceFile = new Path("TestFile.cpp"),
-                    TargetFile = new Path("obj/TestFile.mock.obj"),
-                };
-                expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
-                {
-                    expectedTranslationUnitArguments,
-                };
-
-                expectedCompileArguments.ResourceFile = new ResourceCompileArguments()
-                {
-                    SourceFile = new Path("Resources.rc"),
-                    TargetFile = new Path("obj/Resources.mock.res"),
-                };
-
-                var expectedLinkArguments = new LinkArguments();
-                expectedLinkArguments.TargetType = LinkTarget.WindowsApplication;
-                expectedLinkArguments.TargetFile = new Path("bin/Program.exe");
-                expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
-                expectedLinkArguments.ObjectFiles = new List<Path>()
-                {
-                    new Path("obj/TestFile.mock.obj"),
-                    new Path("obj/Resources.mock.res"),
-                };
-                expectedLinkArguments.LibraryFiles = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.a"),
-                    new Path("../OtherModule2.mock.a"),
-                };
-
-                // Verify expected compiler calls
-                Assert.Equal(
-                    new List<SharedCompileArguments>()
-                    {
-                        expectedCompileArguments,
-                    },
-                    compiler.GetCompileRequests());
-                Assert.Equal(
-                    new List<LinkArguments>()
-                    {
-                        expectedLinkArguments,
-                    },
-                    compiler.GetLinkRequests());
-
-                var expectedBuildOperations = new List<BuildOperation>()
-                {
-                    new BuildOperation(
-                        "MakeDir [./obj/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./obj/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./obj/"),
-                        }),
-                    new BuildOperation(
-                        "MakeDir [./bin/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./bin/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./bin/"),
-                        }),
-                    new BuildOperation(
-                        "MockCompile: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("TestFile.cpp"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("obj/TestFile.mock.obj"),
-                        }),
-                    new BuildOperation(
-                        "MockLink: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockLinker.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("InputFile.in"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("OutputFile.out"),
-                        }),
-                };
-
-                Assert.Equal(
-                    expectedBuildOperations,
-                    result.BuildOperations);
-
-                Assert.Equal(
-                    new List<Path>(),
-                    result.ModuleDependencies);
-
-                Assert.Equal(
-                    new List<Path>(),
-                    result.LinkDependencies);
-
-                Assert.Equal(
-                    new List<Path>()
-                    {
-                        new Path("C:/target/bin/Program.exe"),
-                    },
-                    result.RuntimeDependencies);
-            }
-        }
-
-        [Fact]
-        public void Build_Executable()
-        {
-            // Register the test process manager
-            var processManager = new MockProcessManager();
-
-            // Register the test listener
-            var testListener = new TestTraceListener();
-            using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
-            using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
-            {
-                // Register the mock compiler
-                var compiler = new Mock.Compiler();
-
-                // Register the test process manager
-
-                // Setup the build arguments
-                var arguments = new BuildArguments();
-                arguments.TargetName = "Program";
-                arguments.TargetType = BuildTargetType.Executable;
-                arguments.LanguageStandard = LanguageStandard.CPP20;
-                arguments.SourceRootDirectory = new Path("C:/source/");
-                arguments.TargetRootDirectory = new Path("C:/target/");
-                arguments.ObjectDirectory = new Path("obj/");
-                arguments.BinaryDirectory = new Path("bin/");
-                arguments.SourceFiles = new List<Path>()
-                {
-                    new Path("TestFile.cpp"),
-                };
-                arguments.OptimizationLevel = BuildOptimizationLevel.None;
-                arguments.LinkDependencies = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.a"),
-                    new Path("../OtherModule2.mock.a"),
-                };
-
-                var uut = new BuildEngine(compiler);
-                var fileSystemState = new FileSystemState();
-                var readAccessList = new List<Path>();
-                var writeAccessList = new List<Path>();
-                var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
-                var result = uut.Execute(buildState, arguments);
-
-                // Verify expected process manager requests
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "GetCurrentProcessFileName",
-                        "GetCurrentProcessFileName",
-                    },
-                    processManager.GetRequests());
-
-                // Verify expected logs
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "INFO: Generate Compile Operation: ./TestFile.cpp",
-                        "INFO: CoreLink",
-                        "INFO: Linking target",
-                        "INFO: Generate Link Operation: ./bin/Program.exe",
-                    },
-                    testListener.GetMessages());
-
-                var expectedCompileArguments = new SharedCompileArguments()
-                {
-                    Standard = LanguageStandard.CPP20,
-                    Optimize = OptimizationLevel.None,
-                    ObjectDirectory = new Path("obj/"),
-                    SourceRootDirectory = new Path("C:/source/"),
-                    TargetRootDirectory = new Path("C:/target/"),
-                };
-
-                var expectedTranslationUnitArguments = new TranslationUnitCompileArguments()
-                {
-                    SourceFile = new Path("TestFile.cpp"),
-                    TargetFile = new Path("obj/TestFile.mock.obj"),
-                };
-                expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
-                {
-                    expectedTranslationUnitArguments,
-                };
-
-                var expectedLinkArguments = new LinkArguments();
-                expectedLinkArguments.TargetType = LinkTarget.Executable;
-                expectedLinkArguments.TargetFile = new Path("bin/Program.exe");
-                expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
-                expectedLinkArguments.ObjectFiles = new List<Path>()
-                {
-                    new Path("obj/TestFile.mock.obj"),
-                };
-                expectedLinkArguments.LibraryFiles = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.a"),
-                    new Path("../OtherModule2.mock.a"),
-                };
-
-                // Verify expected compiler calls
-                Assert.Equal(
-                    new List<SharedCompileArguments>()
-                    {
-                        expectedCompileArguments,
-                    },
-                    compiler.GetCompileRequests());
-                Assert.Equal(
-                    new List<LinkArguments>()
-                    {
-                        expectedLinkArguments,
-                    },
-                    compiler.GetLinkRequests());
-
-                var expectedBuildOperations = new List<BuildOperation>()
-                {
-                    new BuildOperation(
-                        "MakeDir [./obj/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./obj/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./obj/"),
-                        }),
-                    new BuildOperation(
-                        "MakeDir [./bin/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./bin/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./bin/"),
-                        }),
-                    new BuildOperation(
-                        "MockCompile: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("TestFile.cpp"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("obj/TestFile.mock.obj"),
-                        }),
-                    new BuildOperation(
-                        "MockLink: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockLinker.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("InputFile.in"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("OutputFile.out"),
-                        }),
-                };
-
-                Assert.Equal(
-                    expectedBuildOperations,
-                    result.BuildOperations);
-
-                Assert.Equal(
-                    new List<Path>(),
-                    result.ModuleDependencies);
-
-                Assert.Equal(
-                    new List<Path>(),
-                    result.LinkDependencies);
-
-                Assert.Equal(
-                    new List<Path>()
-                    {
-                        new Path("C:/target/bin/Program.exe"),
-                    },
-                    result.RuntimeDependencies);
-            }
-        }
-
-        [Fact]
-        public void Build_Library_MultipleFiles()
-        {
-            // Register the test process manager
-            var processManager = new MockProcessManager();
-
-            // Register the test listener
-            var testListener = new TestTraceListener();
-            using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
-            using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
-            {
-                // Register the mock compiler
-                var compiler = new Mock.Compiler();
-
-                // Setup the build arguments
-                var arguments = new BuildArguments();
-                arguments.TargetName = "Library";
-                arguments.TargetType = BuildTargetType.StaticLibrary;
-                arguments.LanguageStandard = LanguageStandard.CPP20;
-                arguments.SourceRootDirectory = new Path("C:/source/");
-                arguments.TargetRootDirectory = new Path("C:/target/");
-                arguments.ObjectDirectory = new Path("obj/");
-                arguments.BinaryDirectory = new Path("bin/");
-                arguments.SourceFiles = new List<Path>()
-                {
-                    new Path("TestFile1.cpp"),
-                    new Path("TestFile2.cpp"),
-                    new Path("TestFile3.cpp"),
-                };
-                arguments.OptimizationLevel = BuildOptimizationLevel.Size;
-                arguments.IncludeDirectories = new List<Path>()
-                {
-                    new Path("Folder"),
-                    new Path("AnotherFolder/Sub"),
-                };
-                arguments.ModuleDependencies = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.bmi"),
-                    new Path("../OtherModule2.mock.bmi"),
-                };
-                arguments.LinkDependencies = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.a"),
-                    new Path("../OtherModule2.mock.a"),
-                };
-
-                var uut = new BuildEngine(compiler);
-                var fileSystemState = new FileSystemState();
-                var readAccessList = new List<Path>();
-                var writeAccessList = new List<Path>();
-                var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
-                var result = uut.Execute(buildState, arguments);
-
-                // Verify expected process manager requests
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "GetCurrentProcessFileName",
-                        "GetCurrentProcessFileName",
-                    },
-                    processManager.GetRequests());
-
-                // Verify expected logs
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "INFO: Generate Compile Operation: ./TestFile1.cpp",
-                        "INFO: Generate Compile Operation: ./TestFile2.cpp",
-                        "INFO: Generate Compile Operation: ./TestFile3.cpp",
-                        "INFO: CoreLink",
-                        "INFO: Linking target",
-                        "INFO: Generate Link Operation: ./bin/Library.mock.lib",
-                    },
-                    testListener.GetMessages());
-
-                // Setup the shared arguments
-                var expectedCompileArguments = new SharedCompileArguments()
-                {
-                    Standard = LanguageStandard.CPP20,
-                    Optimize = OptimizationLevel.Size,
-                    SourceRootDirectory = new Path("C:/source/"),
-                    TargetRootDirectory = new Path("C:/target/"),
-                    ObjectDirectory = new Path("obj/"),
-                    IncludeDirectories = new List<Path>()
-                    {
-                        new Path("Folder"),
-                        new Path("AnotherFolder/Sub"),
-                    },
-                    IncludeModules = new List<Path>()
-                    {
-                        new Path("../Other/bin/OtherModule1.mock.bmi"),
-                        new Path("../OtherModule2.mock.bmi"),
-                    },
-                };
-
-                var expectedTranslationUnit1Arguments = new TranslationUnitCompileArguments();
-                expectedTranslationUnit1Arguments.SourceFile = new Path("TestFile1.cpp");
-                expectedTranslationUnit1Arguments.TargetFile = new Path("obj/TestFile1.mock.obj");
-
-                var expectedTranslationUnit2Arguments = new TranslationUnitCompileArguments();
-                expectedTranslationUnit2Arguments.SourceFile = new Path("TestFile2.cpp");
-                expectedTranslationUnit2Arguments.TargetFile = new Path("obj/TestFile2.mock.obj");
-
-                var expectedTranslationUnit3Arguments = new TranslationUnitCompileArguments();
-                expectedTranslationUnit3Arguments.SourceFile = new Path("TestFile3.cpp");
-                expectedTranslationUnit3Arguments.TargetFile = new Path("obj/TestFile3.mock.obj");
-
-                expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
-                {
-                    expectedTranslationUnit1Arguments,
-                    expectedTranslationUnit2Arguments,
-                    expectedTranslationUnit3Arguments,
-                };
-
-                var expectedLinkArguments = new LinkArguments();
-                expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
-                expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
-                expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
-                expectedLinkArguments.ObjectFiles = new List<Path>()
-                {
-                    new Path("obj/TestFile1.mock.obj"),
-                    new Path("obj/TestFile2.mock.obj"),
-                    new Path("obj/TestFile3.mock.obj"),
-                };
-
-                // Note: There is no need to send along the static libraries for a static library linking
-                expectedLinkArguments.LibraryFiles = new List<Path>();
-
-                // Verify expected compiler calls
-                Assert.Equal(
-                    new List<SharedCompileArguments>()
-                    {
-                        expectedCompileArguments,
-                    },
-                    compiler.GetCompileRequests());
-                Assert.Equal(
-                    new List<LinkArguments>()
-                    {
-                        expectedLinkArguments,
-                    },
-                    compiler.GetLinkRequests());
-
-                // Verify build state
-                var expectedBuildOperations = new List<BuildOperation>()
-                {
-                    new BuildOperation(
-                        "MakeDir [./obj/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./obj/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./obj/"),
-                        }),
-                    new BuildOperation(
-                        "MakeDir [./bin/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./bin/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./bin/"),
-                        }),
-                    new BuildOperation(
-                        "MockCompile: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("TestFile1.cpp"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("obj/TestFile1.mock.obj"),
-                        }),
-                    new BuildOperation(
-                        "MockCompile: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("TestFile2.cpp"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("obj/TestFile2.mock.obj"),
-                        }),
-                    new BuildOperation(
-                        "MockCompile: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("TestFile3.cpp"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("obj/TestFile3.mock.obj"),
-                        }),
-                    new BuildOperation(
-                        "MockLink: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockLinker.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("InputFile.in"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("OutputFile.out"),
-                        }),
-                };
-
-                Assert.Equal(
-                    expectedBuildOperations,
-                    result.BuildOperations);
-
-                Assert.Equal(
-                    new List<Path>(),
-                    result.ModuleDependencies);
-
-                Assert.Equal(
-                    new List<Path>()
-                    {
-                        new Path("../Other/bin/OtherModule1.mock.a"),
-                        new Path("../OtherModule2.mock.a"),
-                        new Path("C:/target/bin/Library.mock.lib"),
-                    },
-                    result.LinkDependencies);
-
-                Assert.Equal(
-                    new List<Path>(),
-                    result.RuntimeDependencies);
-
-                Assert.Equal(
-                    new Path(),
-                    result.TargetFile);
-            }
-        }
-
-        [Fact]
-        public void Build_Library_ModuleInterface()
-        {
-            // Register the test process manager
-            var processManager = new MockProcessManager();
-
-            // Register the test listener
-            var testListener = new TestTraceListener();
-            using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
-            using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
-            {
-                // Register the mock compiler
-                var compiler = new Mock.Compiler();
-
-                // Setup the build arguments
-                var arguments = new BuildArguments();
-                arguments.TargetName = "Library";
-                arguments.TargetType = BuildTargetType.StaticLibrary;
-                arguments.LanguageStandard = LanguageStandard.CPP20;
-                arguments.SourceRootDirectory = new Path("C:/source/");
-                arguments.TargetRootDirectory = new Path("C:/target/");
-                arguments.ObjectDirectory = new Path("obj/");
-                arguments.BinaryDirectory = new Path("bin/");
-                arguments.ModuleInterfaceSourceFile = new Path("Public.cpp");
-                arguments.SourceFiles = new List<Path>()
-                {
-                    new Path("TestFile1.cpp"),
-                    new Path("TestFile2.cpp"),
-                    new Path("TestFile3.cpp"),
-                };
-                arguments.OptimizationLevel = BuildOptimizationLevel.None;
-                arguments.IncludeDirectories = new List<Path>()
-                {
-                    new Path("Folder"),
-                    new Path("AnotherFolder/Sub"),
-                };
-                arguments.ModuleDependencies = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.bmi"),
-                    new Path("../OtherModule2.mock.bmi"),
-                };
-                arguments.LinkDependencies = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.a"),
-                    new Path("../OtherModule2.mock.a"),
-                };
-                arguments.PreprocessorDefinitions = new List<string>()
-                {
-                    "DEBUG",
-                    "AWESOME",
-                };
-
-                var uut = new BuildEngine(compiler);
-                var fileSystemState = new FileSystemState();
-                var readAccessList = new List<Path>();
-                var writeAccessList = new List<Path>();
-                var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
-                var result = uut.Execute(buildState, arguments);
-
-                // Verify expected process manager requests
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "GetCurrentProcessFileName",
-                        "GetCurrentProcessFileName",
-                        "GetCurrentProcessFileName",
-                    },
-                    processManager.GetRequests());
-
-                // Verify expected logs
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "INFO: Generate Module Interface Unit Compile: ./Public.cpp",
-                        "INFO: Generate Compile Operation: ./TestFile1.cpp",
-                        "INFO: Generate Compile Operation: ./TestFile2.cpp",
-                        "INFO: Generate Compile Operation: ./TestFile3.cpp",
-                        "INFO: CoreLink",
-                        "INFO: Linking target",
-                        "INFO: Generate Link Operation: ./bin/Library.mock.lib",
-                    },
-                    testListener.GetMessages());
-
-                // Setup the shared arguments
-                var expectedCompileArguments = new SharedCompileArguments()
-                {
-                    Standard = LanguageStandard.CPP20,
-                    Optimize = OptimizationLevel.None,
-                    SourceRootDirectory = new Path("C:/source/"),
-                    TargetRootDirectory = new Path("C:/target/"),
-                    ObjectDirectory = new Path("obj/"),
-                    IncludeDirectories = new List<Path>()
-                    {
-                        new Path("Folder"),
-                        new Path("AnotherFolder/Sub"),
-                    },
-                    IncludeModules = new List<Path>()
-                    {
-                        new Path("../Other/bin/OtherModule1.mock.bmi"),
-                        new Path("../OtherModule2.mock.bmi"),
-                    },
-                    PreprocessorDefinitions = new List<string>()
-                    {
-                        "DEBUG",
-                        "AWESOME",
-                    },
-                };
-
-                var expectedCompileModuleArguments = new InterfaceUnitCompileArguments()
-                {
-                    SourceFile = new Path("Public.cpp"),
-                    TargetFile = new Path("obj/Public.mock.obj"),
-                    ModuleInterfaceTarget = new Path("obj/Public.mock.bmi"),
-                };
-                expectedCompileArguments.InterfaceUnit = expectedCompileModuleArguments;
-
-                var expectedTranslationUnit1Arguments = new TranslationUnitCompileArguments();
-                expectedTranslationUnit1Arguments.SourceFile = new Path("TestFile1.cpp");
-                expectedTranslationUnit1Arguments.TargetFile = new Path("obj/TestFile1.mock.obj");
-
-                var expectedTranslationUnit2Arguments = new TranslationUnitCompileArguments();
-                expectedTranslationUnit2Arguments.SourceFile = new Path("TestFile2.cpp");
-                expectedTranslationUnit2Arguments.TargetFile = new Path("obj/TestFile2.mock.obj");
-
-                var expectedTranslationUnit3Arguments = new TranslationUnitCompileArguments();
-                expectedTranslationUnit3Arguments.SourceFile = new Path("TestFile3.cpp");
-                expectedTranslationUnit3Arguments.TargetFile = new Path("obj/TestFile3.mock.obj");
-
-                expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
-                {
-                    expectedTranslationUnit1Arguments,
-                    expectedTranslationUnit2Arguments,
-                    expectedTranslationUnit3Arguments,
-                };
-
-                var expectedLinkArguments = new LinkArguments();
-                expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
-                expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
-                expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
-                expectedLinkArguments.ObjectFiles = new List<Path>()
-                {
-                    new Path("obj/TestFile1.mock.obj"),
-                    new Path("obj/TestFile2.mock.obj"),
-                    new Path("obj/TestFile3.mock.obj"),
-                    new Path("obj/Public.mock.obj"),
-                };
-                expectedLinkArguments.LibraryFiles = new List<Path>();
-
-                // Verify expected compiler calls
-                Assert.Equal(
-                    new List<SharedCompileArguments>()
-                    {
-                        expectedCompileArguments,
-                    },
-                    compiler.GetCompileRequests());
-                Assert.Equal(
-                    new List<LinkArguments>()
-                    {
-                        expectedLinkArguments,
-                    },
-                    compiler.GetLinkRequests());
-
-                // Verify build state
-                var expectedBuildOperations = new List<BuildOperation>()
-                {
-                    new BuildOperation(
-                        "MakeDir [./obj/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./obj/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                        new Path("./obj/"),
-                        }),
-                    new BuildOperation(
-                        "MakeDir [./bin/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./bin/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./bin/"),
-                        }),
-                    new BuildOperation(
-                        "Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
-                        new Path("C:/target/"),
-                        new Path("C:/copy.exe"),
-                        "\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
-                        new List<Path>()
-                        {
-                            new Path("./obj/Public.mock.bmi"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("./bin/Library.mock.bmi"),
-                        }),
-                    new BuildOperation(
-                        "MockCompileModule: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("InputFile.in"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("OutputFile.out"),
-                        }),
-                    new BuildOperation(
-                        "MockCompile: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("TestFile1.cpp"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("obj/TestFile1.mock.obj"),
-                        }),
-                    new BuildOperation(
-                        "MockCompile: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("TestFile2.cpp"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("obj/TestFile2.mock.obj"),
-                        }),
-                    new BuildOperation(
-                        "MockCompile: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("TestFile3.cpp"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("obj/TestFile3.mock.obj"),
-                        }),
-                    new BuildOperation(
-                        "MockLink: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockLinker.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("InputFile.in"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("OutputFile.out"),
-                        }),
-                };
-
-                Assert.Equal(
-                    expectedBuildOperations,
-                    result.BuildOperations);
-
-                Assert.Equal(
-                    new List<Path>()
-                    {
-                    new Path("C:/target/bin/Library.mock.bmi"),
-                    },
-                    result.ModuleDependencies);
-
-                Assert.Equal(
-                    new List<Path>()
-                    {
-                        new Path("../Other/bin/OtherModule1.mock.a"),
-                        new Path("../OtherModule2.mock.a"),
-                        new Path("C:/target/bin/Library.mock.lib"),
-                    },
-                    result.LinkDependencies);
-
-                Assert.Equal(
-                    new List<Path>(),
-                    result.RuntimeDependencies);
-
-                Assert.Equal(
-                    new Path(),
-                    result.TargetFile);
-            }
-        }
-
-        [Fact]
-        public void Build_Library_ModuleInterfaceNoSource()
-        {
-            // Register the test process manager
-            var processManager = new MockProcessManager();
-
-            // Register the test listener
-            var testListener = new TestTraceListener();
-            using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
-            using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
-            {
-                // Register the mock compiler
-                var compiler = new Mock.Compiler();
-
-                // Setup the build arguments
-                var arguments = new BuildArguments();
-                arguments.TargetName = "Library";
-                arguments.TargetType = BuildTargetType.StaticLibrary;
-                arguments.LanguageStandard = LanguageStandard.CPP20;
-                arguments.SourceRootDirectory = new Path("C:/source/");
-                arguments.TargetRootDirectory = new Path("C:/target/");
-                arguments.ObjectDirectory = new Path("obj/");
-                arguments.BinaryDirectory = new Path("bin/");
-                arguments.ModuleInterfaceSourceFile = new Path("Public.cpp");
-                arguments.SourceFiles = new List<Path>();
-                arguments.OptimizationLevel = BuildOptimizationLevel.Size;
-                arguments.IncludeDirectories = new List<Path>()
-                {
-                    new Path("Folder"),
-                    new Path("AnotherFolder/Sub"),
-                };
-                arguments.ModuleDependencies = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.bmi"),
-                    new Path("../OtherModule2.mock.bmi"),
-                };
-                arguments.LinkDependencies = new List<Path>()
-                {
-                    new Path("../Other/bin/OtherModule1.mock.a"),
-                    new Path("../OtherModule2.mock.a"),
-                };
-
-                var uut = new BuildEngine(compiler);
-                var fileSystemState = new FileSystemState();
-                var readAccessList = new List<Path>();
-                var writeAccessList = new List<Path>();
-                var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
-                var result = uut.Execute(buildState, arguments);
-
-                // Verify expected process manager requests
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "GetCurrentProcessFileName",
-                        "GetCurrentProcessFileName",
-                        "GetCurrentProcessFileName",
-                    },
-                    processManager.GetRequests());
-
-                // Verify expected logs
-                Assert.Equal(
-                    new List<string>()
-                    {
-                        "INFO: Generate Module Interface Unit Compile: ./Public.cpp",
-                        "INFO: CoreLink",
-                        "INFO: Linking target",
-                        "INFO: Generate Link Operation: ./bin/Library.mock.lib",
-                    },
-                    testListener.GetMessages());
-
-                // Setup the shared arguments
-                var expectedCompileArguments = new SharedCompileArguments()
-                {
-                    Standard = LanguageStandard.CPP20,
-                    Optimize = OptimizationLevel.Size,
-                    SourceRootDirectory = new Path("C:/source/"),
-                    TargetRootDirectory = new Path("C:/target/"),
-                    ObjectDirectory = new Path("obj/"),
-                    IncludeDirectories = new List<Path>()
-                    {
-                        new Path("Folder"),
-                        new Path("AnotherFolder/Sub"),
-                    },
-                    IncludeModules = new List<Path>()
-                    {
-                        new Path("../Other/bin/OtherModule1.mock.bmi"),
-                        new Path("../OtherModule2.mock.bmi"),
-                    },
-                };
-
-                var expectedCompileModuleArguments = new InterfaceUnitCompileArguments()
-                {
-                    SourceFile = new Path("Public.cpp"),
-                    TargetFile = new Path("obj/Public.mock.obj"),
-                    ModuleInterfaceTarget = new Path("obj/Public.mock.bmi"),
-                };
-                expectedCompileArguments.InterfaceUnit = expectedCompileModuleArguments;
-
-                var expectedLinkArguments = new LinkArguments();
-                expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
-                expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
-                expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
-                expectedLinkArguments.ObjectFiles = new List<Path>()
-                {
-                    new Path("obj/Public.mock.obj"),
-                };
-                expectedLinkArguments.LibraryFiles = new List<Path>();
-
-                // Verify expected compiler calls
-                Assert.Equal(
-                    new List<SharedCompileArguments>()
-                    {
-                        expectedCompileArguments,
-                    },
-                    compiler.GetCompileRequests());
-                Assert.Equal(
-                    new List<LinkArguments>()
-                    {
-                        expectedLinkArguments,
-                    },
-                    compiler.GetLinkRequests());
-
-                // Verify build state
-                var expectedBuildOperations = new List<BuildOperation>()
-                {
-                    new BuildOperation(
-                        "MakeDir [./obj/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./obj/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./obj/"),
-                        }),
-                    new BuildOperation(
-                        "MakeDir [./bin/]",
-                        new Path("C:/target/"),
-                        new Path("C:/mkdir.exe"),
-                        "\"./bin/\"",
-                        new List<Path>(),
-                        new List<Path>()
-                        {
-                            new Path("./bin/"),
-                        }),
-                    new BuildOperation(
-                        "Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
-                        new Path("C:/target/"),
-                        new Path("C:/copy.exe"),
-                        "\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
-                        new List<Path>()
-                        {
-                            new Path("./obj/Public.mock.bmi"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("./bin/Library.mock.bmi"),
-                        }),
-                    new BuildOperation(
-                        "MockCompileModule: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockCompiler.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("InputFile.in"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("OutputFile.out"),
-                        }),
-                    new BuildOperation(
-                        "MockLink: 1",
-                        new Path("MockWorkingDirectory"),
-                        new Path("MockLinker.exe"),
-                        "Arguments",
-                        new List<Path>()
-                        {
-                            new Path("InputFile.in"),
-                        },
-                        new List<Path>()
-                        {
-                            new Path("OutputFile.out"),
-                        }),
-                };
-
-                Assert.Equal(
-                    expectedBuildOperations,
-                    result.BuildOperations);
-
-                Assert.Equal(
-                    new List<Path>()
-                    {
-                        new Path("C:/target/bin/Library.mock.bmi"),
-                    },
-                    result.ModuleDependencies);
-
-                Assert.Equal(
-                    new List<Path>()
-                    {
-                        new Path("../Other/bin/OtherModule1.mock.a"),
-                        new Path("../OtherModule2.mock.a"),
-                        new Path("C:/target/bin/Library.mock.lib"),
-                    },
-                    result.LinkDependencies);
-
-                Assert.Equal(
-                    new List<Path>(),
-                    result.RuntimeDependencies);
-
-                Assert.Equal(
-                    new Path(),
-                    result.TargetFile);
-            }
-        }
-    }
+	public class BuildEngineUnitTests
+	{
+		[Fact]
+		public void Initialize_Success()
+		{
+			var compiler = new Mock.Compiler();
+			var uut = new BuildEngine(compiler);
+		}
+
+		[Fact]
+		public void Build_WindowsApplication()
+		{
+			// Register the test process manager
+			var processManager = new MockProcessManager();
+
+			// Register the test listener
+			var testListener = new TestTraceListener();
+			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+			{
+				// Register the mock compiler
+				var compiler = new Mock.Compiler();
+
+				// Register the test process manager
+
+				// Setup the build arguments
+				var arguments = new BuildArguments();
+				arguments.TargetName = "Program";
+				arguments.TargetType = BuildTargetType.WindowsApplication;
+				arguments.LanguageStandard = LanguageStandard.CPP20;
+				arguments.SourceRootDirectory = new Path("C:/source/");
+				arguments.TargetRootDirectory = new Path("C:/target/");
+				arguments.ObjectDirectory = new Path("obj/");
+				arguments.BinaryDirectory = new Path("bin/");
+				arguments.SourceFiles = new List<Path>()
+				{
+					new Path("TestFile.cpp"),
+				};
+				arguments.OptimizationLevel = BuildOptimizationLevel.None;
+				arguments.LinkDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.a"),
+					new Path("../OtherModule2.mock.a"),
+				};
+
+				var uut = new BuildEngine(compiler);
+				var fileSystemState = new FileSystemState();
+				var readAccessList = new List<Path>();
+				var writeAccessList = new List<Path>();
+				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+				var result = uut.Execute(buildState, arguments);
+
+				// Verify expected process manager requests
+				Assert.Equal(
+					new List<string>()
+					{
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+					},
+					processManager.GetRequests());
+
+				// Verify expected logs
+				Assert.Equal(
+					new List<string>()
+					{
+						"INFO: Generate Compile Operation: ./TestFile.cpp",
+						"INFO: CoreLink",
+						"INFO: Linking target",
+						"INFO: Generate Link Operation: ./bin/Program.exe",
+					},
+					testListener.GetMessages());
+
+				var expectedCompileArguments = new SharedCompileArguments()
+				{
+					Standard = LanguageStandard.CPP20,
+					Optimize = OptimizationLevel.None,
+					ObjectDirectory = new Path("obj/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
+				};
+
+				var expectedTranslationUnitArguments = new TranslationUnitCompileArguments()
+				{
+					SourceFile = new Path("TestFile.cpp"),
+					TargetFile = new Path("obj/TestFile.mock.obj"),
+				};
+				expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
+				{
+					expectedTranslationUnitArguments,
+				};
+
+				var expectedLinkArguments = new LinkArguments();
+				expectedLinkArguments.TargetType = LinkTarget.WindowsApplication;
+				expectedLinkArguments.TargetFile = new Path("bin/Program.exe");
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+				expectedLinkArguments.ObjectFiles = new List<Path>()
+				{
+					new Path("obj/TestFile.mock.obj"),
+				};
+				expectedLinkArguments.LibraryFiles = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.a"),
+					new Path("../OtherModule2.mock.a"),
+				};
+
+				// Verify expected compiler calls
+				Assert.Equal(
+					new List<SharedCompileArguments>()
+					{
+						expectedCompileArguments,
+					},
+					compiler.GetCompileRequests());
+				Assert.Equal(
+					new List<LinkArguments>()
+					{
+						expectedLinkArguments,
+					},
+					compiler.GetLinkRequests());
+
+				var expectedBuildOperations = new List<BuildOperation>()
+				{
+					new BuildOperation(
+						"MakeDir [./obj/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./obj/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("./obj/"),
+						}),
+					new BuildOperation(
+						"MakeDir [./bin/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./bin/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("./bin/"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockLink: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockLinker.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("InputFile.in"),
+						},
+						new List<Path>()
+						{
+							new Path("OutputFile.out"),
+						}),
+				};
+
+				Assert.Equal(
+					expectedBuildOperations,
+					result.BuildOperations);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.ModuleDependencies);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.LinkDependencies);
+
+				Assert.Equal(
+					new List<Path>()
+					{
+						new Path("C:/target/bin/Program.exe"),
+					},
+					result.RuntimeDependencies);
+			}
+		}
+
+		[Fact]
+		public void Build_WindowsApplicationWithResource()
+		{
+			// Register the test process manager
+			var processManager = new MockProcessManager();
+
+			// Register the test listener
+			var testListener = new TestTraceListener();
+			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+			{
+				// Register the mock compiler
+				var compiler = new Mock.Compiler();
+
+				// Register the test process manager
+
+				// Setup the build arguments
+				var arguments = new BuildArguments();
+				arguments.TargetName = "Program";
+				arguments.TargetType = BuildTargetType.WindowsApplication;
+				arguments.LanguageStandard = LanguageStandard.CPP20;
+				arguments.SourceRootDirectory = new Path("C:/source/");
+				arguments.TargetRootDirectory = new Path("C:/target/");
+				arguments.ObjectDirectory = new Path("obj/");
+				arguments.BinaryDirectory = new Path("bin/");
+				arguments.SourceFiles = new List<Path>()
+				{
+					new Path("TestFile.cpp"),
+				};
+				arguments.ResourceFile = new Path("Resources.rc");
+				arguments.OptimizationLevel = BuildOptimizationLevel.None;
+				arguments.LinkDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.a"),
+					new Path("../OtherModule2.mock.a"),
+				};
+
+				var uut = new BuildEngine(compiler);
+				var fileSystemState = new FileSystemState();
+				var readAccessList = new List<Path>();
+				var writeAccessList = new List<Path>();
+				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+				var result = uut.Execute(buildState, arguments);
+
+				// Verify expected process manager requests
+				Assert.Equal(
+					new List<string>()
+					{
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+					},
+					processManager.GetRequests());
+
+				// Verify expected logs
+				Assert.Equal(
+					new List<string>()
+					{
+						"INFO: Generate Resource File Compile: ./Resources.rc",
+						"INFO: Generate Compile Operation: ./TestFile.cpp",
+						"INFO: CoreLink",
+						"INFO: Linking target",
+						"INFO: Generate Link Operation: ./bin/Program.exe",
+					},
+					testListener.GetMessages());
+
+				var expectedCompileArguments = new SharedCompileArguments()
+				{
+					Standard = LanguageStandard.CPP20,
+					Optimize = OptimizationLevel.None,
+					ObjectDirectory = new Path("obj/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
+				};
+
+				var expectedTranslationUnitArguments = new TranslationUnitCompileArguments()
+				{
+					SourceFile = new Path("TestFile.cpp"),
+					TargetFile = new Path("obj/TestFile.mock.obj"),
+				};
+				expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
+				{
+					expectedTranslationUnitArguments,
+				};
+
+				expectedCompileArguments.ResourceFile = new ResourceCompileArguments()
+				{
+					SourceFile = new Path("Resources.rc"),
+					TargetFile = new Path("obj/Resources.mock.res"),
+				};
+
+				var expectedLinkArguments = new LinkArguments();
+				expectedLinkArguments.TargetType = LinkTarget.WindowsApplication;
+				expectedLinkArguments.TargetFile = new Path("bin/Program.exe");
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+				expectedLinkArguments.ObjectFiles = new List<Path>()
+				{
+					new Path("obj/Resources.mock.res"),
+					new Path("obj/TestFile.mock.obj"),
+				};
+				expectedLinkArguments.LibraryFiles = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.a"),
+					new Path("../OtherModule2.mock.a"),
+				};
+
+				// Verify expected compiler calls
+				Assert.Equal(
+					new List<SharedCompileArguments>()
+					{
+						expectedCompileArguments,
+					},
+					compiler.GetCompileRequests());
+				Assert.Equal(
+					new List<LinkArguments>()
+					{
+						expectedLinkArguments,
+					},
+					compiler.GetLinkRequests());
+
+				var expectedBuildOperations = new List<BuildOperation>()
+				{
+					new BuildOperation(
+						"MakeDir [./obj/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./obj/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("./obj/"),
+						}),
+					new BuildOperation(
+						"MakeDir [./bin/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./bin/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("./bin/"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockLink: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockLinker.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("InputFile.in"),
+						},
+						new List<Path>()
+						{
+							new Path("OutputFile.out"),
+						}),
+				};
+
+				Assert.Equal(
+					expectedBuildOperations,
+					result.BuildOperations);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.ModuleDependencies);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.LinkDependencies);
+
+				Assert.Equal(
+					new List<Path>()
+					{
+						new Path("C:/target/bin/Program.exe"),
+					},
+					result.RuntimeDependencies);
+			}
+		}
+
+		[Fact]
+		public void Build_Executable()
+		{
+			// Register the test process manager
+			var processManager = new MockProcessManager();
+
+			// Register the test listener
+			var testListener = new TestTraceListener();
+			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+			{
+				// Register the mock compiler
+				var compiler = new Mock.Compiler();
+
+				// Register the test process manager
+
+				// Setup the build arguments
+				var arguments = new BuildArguments();
+				arguments.TargetName = "Program";
+				arguments.TargetType = BuildTargetType.Executable;
+				arguments.LanguageStandard = LanguageStandard.CPP20;
+				arguments.SourceRootDirectory = new Path("C:/source/");
+				arguments.TargetRootDirectory = new Path("C:/target/");
+				arguments.ObjectDirectory = new Path("obj/");
+				arguments.BinaryDirectory = new Path("bin/");
+				arguments.SourceFiles = new List<Path>()
+				{
+					new Path("TestFile.cpp"),
+				};
+				arguments.OptimizationLevel = BuildOptimizationLevel.None;
+				arguments.LinkDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.a"),
+					new Path("../OtherModule2.mock.a"),
+				};
+
+				var uut = new BuildEngine(compiler);
+				var fileSystemState = new FileSystemState();
+				var readAccessList = new List<Path>();
+				var writeAccessList = new List<Path>();
+				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+				var result = uut.Execute(buildState, arguments);
+
+				// Verify expected process manager requests
+				Assert.Equal(
+					new List<string>()
+					{
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+					},
+					processManager.GetRequests());
+
+				// Verify expected logs
+				Assert.Equal(
+					new List<string>()
+					{
+						"INFO: Generate Compile Operation: ./TestFile.cpp",
+						"INFO: CoreLink",
+						"INFO: Linking target",
+						"INFO: Generate Link Operation: ./bin/Program.exe",
+					},
+					testListener.GetMessages());
+
+				var expectedCompileArguments = new SharedCompileArguments()
+				{
+					Standard = LanguageStandard.CPP20,
+					Optimize = OptimizationLevel.None,
+					ObjectDirectory = new Path("obj/"),
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
+				};
+
+				var expectedTranslationUnitArguments = new TranslationUnitCompileArguments()
+				{
+					SourceFile = new Path("TestFile.cpp"),
+					TargetFile = new Path("obj/TestFile.mock.obj"),
+				};
+				expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
+				{
+					expectedTranslationUnitArguments,
+				};
+
+				var expectedLinkArguments = new LinkArguments();
+				expectedLinkArguments.TargetType = LinkTarget.Executable;
+				expectedLinkArguments.TargetFile = new Path("bin/Program.exe");
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+				expectedLinkArguments.ObjectFiles = new List<Path>()
+				{
+					new Path("obj/TestFile.mock.obj"),
+				};
+				expectedLinkArguments.LibraryFiles = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.a"),
+					new Path("../OtherModule2.mock.a"),
+				};
+
+				// Verify expected compiler calls
+				Assert.Equal(
+					new List<SharedCompileArguments>()
+					{
+						expectedCompileArguments,
+					},
+					compiler.GetCompileRequests());
+				Assert.Equal(
+					new List<LinkArguments>()
+					{
+						expectedLinkArguments,
+					},
+					compiler.GetLinkRequests());
+
+				var expectedBuildOperations = new List<BuildOperation>()
+				{
+					new BuildOperation(
+						"MakeDir [./obj/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./obj/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("./obj/"),
+						}),
+					new BuildOperation(
+						"MakeDir [./bin/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./bin/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("./bin/"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockLink: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockLinker.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("InputFile.in"),
+						},
+						new List<Path>()
+						{
+							new Path("OutputFile.out"),
+						}),
+				};
+
+				Assert.Equal(
+					expectedBuildOperations,
+					result.BuildOperations);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.ModuleDependencies);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.LinkDependencies);
+
+				Assert.Equal(
+					new List<Path>()
+					{
+						new Path("C:/target/bin/Program.exe"),
+					},
+					result.RuntimeDependencies);
+			}
+		}
+
+		[Fact]
+		public void Build_Library_MultipleFiles()
+		{
+			// Register the test process manager
+			var processManager = new MockProcessManager();
+
+			// Register the test listener
+			var testListener = new TestTraceListener();
+			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+			{
+				// Register the mock compiler
+				var compiler = new Mock.Compiler();
+
+				// Setup the build arguments
+				var arguments = new BuildArguments();
+				arguments.TargetName = "Library";
+				arguments.TargetType = BuildTargetType.StaticLibrary;
+				arguments.LanguageStandard = LanguageStandard.CPP20;
+				arguments.SourceRootDirectory = new Path("C:/source/");
+				arguments.TargetRootDirectory = new Path("C:/target/");
+				arguments.ObjectDirectory = new Path("obj/");
+				arguments.BinaryDirectory = new Path("bin/");
+				arguments.SourceFiles = new List<Path>()
+				{
+					new Path("TestFile1.cpp"),
+					new Path("TestFile2.cpp"),
+					new Path("TestFile3.cpp"),
+				};
+				arguments.OptimizationLevel = BuildOptimizationLevel.Size;
+				arguments.IncludeDirectories = new List<Path>()
+				{
+					new Path("Folder"),
+					new Path("AnotherFolder/Sub"),
+				};
+				arguments.ModuleDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.bmi"),
+					new Path("../OtherModule2.mock.bmi"),
+				};
+				arguments.LinkDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.a"),
+					new Path("../OtherModule2.mock.a"),
+				};
+
+				var uut = new BuildEngine(compiler);
+				var fileSystemState = new FileSystemState();
+				var readAccessList = new List<Path>();
+				var writeAccessList = new List<Path>();
+				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+				var result = uut.Execute(buildState, arguments);
+
+				// Verify expected process manager requests
+				Assert.Equal(
+					new List<string>()
+					{
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+					},
+					processManager.GetRequests());
+
+				// Verify expected logs
+				Assert.Equal(
+					new List<string>()
+					{
+						"INFO: Generate Compile Operation: ./TestFile1.cpp",
+						"INFO: Generate Compile Operation: ./TestFile2.cpp",
+						"INFO: Generate Compile Operation: ./TestFile3.cpp",
+						"INFO: CoreLink",
+						"INFO: Linking target",
+						"INFO: Generate Link Operation: ./bin/Library.mock.lib",
+					},
+					testListener.GetMessages());
+
+				// Setup the shared arguments
+				var expectedCompileArguments = new SharedCompileArguments()
+				{
+					Standard = LanguageStandard.CPP20,
+					Optimize = OptimizationLevel.Size,
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
+					ObjectDirectory = new Path("obj/"),
+					IncludeDirectories = new List<Path>()
+					{
+						new Path("Folder"),
+						new Path("AnotherFolder/Sub"),
+					},
+					IncludeModules = new List<Path>()
+					{
+						new Path("../Other/bin/OtherModule1.mock.bmi"),
+						new Path("../OtherModule2.mock.bmi"),
+					},
+				};
+
+				var expectedTranslationUnit1Arguments = new TranslationUnitCompileArguments();
+				expectedTranslationUnit1Arguments.SourceFile = new Path("TestFile1.cpp");
+				expectedTranslationUnit1Arguments.TargetFile = new Path("obj/TestFile1.mock.obj");
+
+				var expectedTranslationUnit2Arguments = new TranslationUnitCompileArguments();
+				expectedTranslationUnit2Arguments.SourceFile = new Path("TestFile2.cpp");
+				expectedTranslationUnit2Arguments.TargetFile = new Path("obj/TestFile2.mock.obj");
+
+				var expectedTranslationUnit3Arguments = new TranslationUnitCompileArguments();
+				expectedTranslationUnit3Arguments.SourceFile = new Path("TestFile3.cpp");
+				expectedTranslationUnit3Arguments.TargetFile = new Path("obj/TestFile3.mock.obj");
+
+				expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
+				{
+					expectedTranslationUnit1Arguments,
+					expectedTranslationUnit2Arguments,
+					expectedTranslationUnit3Arguments,
+				};
+
+				var expectedLinkArguments = new LinkArguments();
+				expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
+				expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+				expectedLinkArguments.ObjectFiles = new List<Path>()
+				{
+					new Path("obj/TestFile1.mock.obj"),
+					new Path("obj/TestFile2.mock.obj"),
+					new Path("obj/TestFile3.mock.obj"),
+				};
+
+				// Note: There is no need to send along the static libraries for a static library linking
+				expectedLinkArguments.LibraryFiles = new List<Path>();
+
+				// Verify expected compiler calls
+				Assert.Equal(
+					new List<SharedCompileArguments>()
+					{
+						expectedCompileArguments,
+					},
+					compiler.GetCompileRequests());
+				Assert.Equal(
+					new List<LinkArguments>()
+					{
+						expectedLinkArguments,
+					},
+					compiler.GetLinkRequests());
+
+				// Verify build state
+				var expectedBuildOperations = new List<BuildOperation>()
+				{
+					new BuildOperation(
+						"MakeDir [./obj/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./obj/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("./obj/"),
+						}),
+					new BuildOperation(
+						"MakeDir [./bin/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./bin/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("./bin/"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile1.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile1.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile2.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile2.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile3.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile3.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockLink: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockLinker.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("InputFile.in"),
+						},
+						new List<Path>()
+						{
+							new Path("OutputFile.out"),
+						}),
+				};
+
+				Assert.Equal(
+					expectedBuildOperations,
+					result.BuildOperations);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.ModuleDependencies);
+
+				Assert.Equal(
+					new List<Path>()
+					{
+						new Path("../Other/bin/OtherModule1.mock.a"),
+						new Path("../OtherModule2.mock.a"),
+						new Path("C:/target/bin/Library.mock.lib"),
+					},
+					result.LinkDependencies);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.RuntimeDependencies);
+
+				Assert.Equal(
+					new Path(),
+					result.TargetFile);
+			}
+		}
+
+		[Fact]
+		public void Build_Library_ModuleInterface()
+		{
+			// Register the test process manager
+			var processManager = new MockProcessManager();
+
+			// Register the test listener
+			var testListener = new TestTraceListener();
+			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+			{
+				// Register the mock compiler
+				var compiler = new Mock.Compiler();
+
+				// Setup the build arguments
+				var arguments = new BuildArguments();
+				arguments.TargetName = "Library";
+				arguments.TargetType = BuildTargetType.StaticLibrary;
+				arguments.LanguageStandard = LanguageStandard.CPP20;
+				arguments.SourceRootDirectory = new Path("C:/source/");
+				arguments.TargetRootDirectory = new Path("C:/target/");
+				arguments.ObjectDirectory = new Path("obj/");
+				arguments.BinaryDirectory = new Path("bin/");
+				arguments.ModuleInterfaceSourceFile = new Path("Public.cpp");
+				arguments.SourceFiles = new List<Path>()
+				{
+					new Path("TestFile1.cpp"),
+					new Path("TestFile2.cpp"),
+					new Path("TestFile3.cpp"),
+				};
+				arguments.OptimizationLevel = BuildOptimizationLevel.None;
+				arguments.IncludeDirectories = new List<Path>()
+				{
+					new Path("Folder"),
+					new Path("AnotherFolder/Sub"),
+				};
+				arguments.ModuleDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.bmi"),
+					new Path("../OtherModule2.mock.bmi"),
+				};
+				arguments.LinkDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.a"),
+					new Path("../OtherModule2.mock.a"),
+				};
+				arguments.PreprocessorDefinitions = new List<string>()
+				{
+					"DEBUG",
+					"AWESOME",
+				};
+
+				var uut = new BuildEngine(compiler);
+				var fileSystemState = new FileSystemState();
+				var readAccessList = new List<Path>();
+				var writeAccessList = new List<Path>();
+				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+				var result = uut.Execute(buildState, arguments);
+
+				// Verify expected process manager requests
+				Assert.Equal(
+					new List<string>()
+					{
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+					},
+					processManager.GetRequests());
+
+				// Verify expected logs
+				Assert.Equal(
+					new List<string>()
+					{
+						"INFO: Generate Module Interface Unit Compile: ./Public.cpp",
+						"INFO: Generate Compile Operation: ./TestFile1.cpp",
+						"INFO: Generate Compile Operation: ./TestFile2.cpp",
+						"INFO: Generate Compile Operation: ./TestFile3.cpp",
+						"INFO: CoreLink",
+						"INFO: Linking target",
+						"INFO: Generate Link Operation: ./bin/Library.mock.lib",
+					},
+					testListener.GetMessages());
+
+				// Setup the shared arguments
+				var expectedCompileArguments = new SharedCompileArguments()
+				{
+					Standard = LanguageStandard.CPP20,
+					Optimize = OptimizationLevel.None,
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
+					ObjectDirectory = new Path("obj/"),
+					IncludeDirectories = new List<Path>()
+					{
+						new Path("Folder"),
+						new Path("AnotherFolder/Sub"),
+					},
+					IncludeModules = new List<Path>()
+					{
+						new Path("../Other/bin/OtherModule1.mock.bmi"),
+						new Path("../OtherModule2.mock.bmi"),
+					},
+					PreprocessorDefinitions = new List<string>()
+					{
+						"DEBUG",
+						"AWESOME",
+					},
+				};
+
+				var expectedCompileModuleArguments = new InterfaceUnitCompileArguments()
+				{
+					SourceFile = new Path("Public.cpp"),
+					TargetFile = new Path("obj/Public.mock.obj"),
+					ModuleInterfaceTarget = new Path("obj/Public.mock.bmi"),
+				};
+				expectedCompileArguments.InterfaceUnit = expectedCompileModuleArguments;
+
+				var expectedTranslationUnit1Arguments = new TranslationUnitCompileArguments();
+				expectedTranslationUnit1Arguments.SourceFile = new Path("TestFile1.cpp");
+				expectedTranslationUnit1Arguments.TargetFile = new Path("obj/TestFile1.mock.obj");
+
+				var expectedTranslationUnit2Arguments = new TranslationUnitCompileArguments();
+				expectedTranslationUnit2Arguments.SourceFile = new Path("TestFile2.cpp");
+				expectedTranslationUnit2Arguments.TargetFile = new Path("obj/TestFile2.mock.obj");
+
+				var expectedTranslationUnit3Arguments = new TranslationUnitCompileArguments();
+				expectedTranslationUnit3Arguments.SourceFile = new Path("TestFile3.cpp");
+				expectedTranslationUnit3Arguments.TargetFile = new Path("obj/TestFile3.mock.obj");
+
+				expectedCompileArguments.ImplementationUnits = new List<TranslationUnitCompileArguments>()
+				{
+					expectedTranslationUnit1Arguments,
+					expectedTranslationUnit2Arguments,
+					expectedTranslationUnit3Arguments,
+				};
+
+				var expectedLinkArguments = new LinkArguments();
+				expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
+				expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+				expectedLinkArguments.ObjectFiles = new List<Path>()
+				{
+					new Path("obj/Public.mock.obj"),
+					new Path("obj/TestFile1.mock.obj"),
+					new Path("obj/TestFile2.mock.obj"),
+					new Path("obj/TestFile3.mock.obj"),
+				};
+				expectedLinkArguments.LibraryFiles = new List<Path>();
+
+				// Verify expected compiler calls
+				Assert.Equal(
+					new List<SharedCompileArguments>()
+					{
+						expectedCompileArguments,
+					},
+					compiler.GetCompileRequests());
+				Assert.Equal(
+					new List<LinkArguments>()
+					{
+						expectedLinkArguments,
+					},
+					compiler.GetLinkRequests());
+
+				// Verify build state
+				var expectedBuildOperations = new List<BuildOperation>()
+				{
+					new BuildOperation(
+						"MakeDir [./obj/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./obj/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("obj/"),
+						}),
+					new BuildOperation(
+						"MakeDir [./bin/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./bin/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("bin/"),
+						}),
+					new BuildOperation(
+						"Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
+						new Path("C:/target/"),
+						new Path("C:/copy.exe"),
+						"\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
+						new List<Path>()
+						{
+							new Path("obj/Public.mock.bmi"),
+						},
+						new List<Path>()
+						{
+							new Path("bin/Library.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompileModule: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("Public.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/Public.mock.obj"),
+							new Path("obj/Public.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile1.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile1.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile2.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile2.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile3.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile3.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockLink: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockLinker.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("InputFile.in"),
+						},
+						new List<Path>()
+						{
+							new Path("OutputFile.out"),
+						}),
+				};
+
+				Assert.Equal(
+					expectedBuildOperations,
+					result.BuildOperations);
+
+				Assert.Equal(
+					new List<Path>()
+					{
+					new Path("C:/target/bin/Library.mock.bmi"),
+					},
+					result.ModuleDependencies);
+
+				Assert.Equal(
+					new List<Path>()
+					{
+						new Path("../Other/bin/OtherModule1.mock.a"),
+						new Path("../OtherModule2.mock.a"),
+						new Path("C:/target/bin/Library.mock.lib"),
+					},
+					result.LinkDependencies);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.RuntimeDependencies);
+
+				Assert.Equal(
+					new Path(),
+					result.TargetFile);
+			}
+		}
+
+		[Fact]
+		public void Build_Library_ModuleInterface_WithPartitions()
+		{
+			// Register the test process manager
+			var processManager = new MockProcessManager();
+
+			// Register the test listener
+			var testListener = new TestTraceListener();
+			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+			{
+				// Register the mock compiler
+				var compiler = new Mock.Compiler();
+
+				// Setup the build arguments
+				var arguments = new BuildArguments();
+				arguments.TargetName = "Library";
+				arguments.TargetType = BuildTargetType.StaticLibrary;
+				arguments.LanguageStandard = LanguageStandard.CPP20;
+				arguments.SourceRootDirectory = new Path("C:/source/");
+				arguments.TargetRootDirectory = new Path("C:/target/");
+				arguments.ObjectDirectory = new Path("obj/");
+				arguments.BinaryDirectory = new Path("bin/");
+				arguments.ModuleInterfacePartitionSourceFiles = new List<Path>()
+				{
+					new Path("TestFile1.cpp"),
+					new Path("TestFile2.cpp"),
+				};
+				arguments.ModuleInterfaceSourceFile = new Path("Public.cpp");
+				arguments.SourceFiles = new List<Path>()
+				{
+					new Path("TestFile3.cpp"),
+					new Path("TestFile4.cpp"),
+				};
+				arguments.OptimizationLevel = BuildOptimizationLevel.None;
+				arguments.IncludeDirectories = new List<Path>()
+				{
+					new Path("Folder"),
+					new Path("AnotherFolder/Sub"),
+				};
+				arguments.ModuleDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.bmi"),
+					new Path("../OtherModule2.mock.bmi"),
+				};
+				arguments.LinkDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.a"),
+					new Path("../OtherModule2.mock.a"),
+				};
+				arguments.PreprocessorDefinitions = new List<string>()
+				{
+					"DEBUG",
+					"AWESOME",
+				};
+
+				var uut = new BuildEngine(compiler);
+				var fileSystemState = new FileSystemState();
+				var readAccessList = new List<Path>();
+				var writeAccessList = new List<Path>();
+				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+				var result = uut.Execute(buildState, arguments);
+
+				// Verify expected process manager requests
+				Assert.Equal(
+					new List<string>()
+					{
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+					},
+					processManager.GetRequests());
+
+				// Verify expected logs
+				Assert.Equal(
+					new List<string>()
+					{
+						"INFO: Generate Module Interface Partition Compile Operation: ./TestFile1.cpp",
+						"INFO: Generate Module Interface Partition Compile Operation: ./TestFile2.cpp",
+						"INFO: Generate Module Interface Unit Compile: ./Public.cpp",
+						"INFO: Generate Compile Operation: ./TestFile3.cpp",
+						"INFO: Generate Compile Operation: ./TestFile4.cpp",
+						"INFO: CoreLink",
+						"INFO: Linking target",
+						"INFO: Generate Link Operation: ./bin/Library.mock.lib",
+					},
+					testListener.GetMessages());
+
+				// Setup the shared arguments
+				var expectedCompileArguments = new SharedCompileArguments()
+				{
+					Standard = LanguageStandard.CPP20,
+					Optimize = OptimizationLevel.None,
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
+					ObjectDirectory = new Path("obj/"),
+					IncludeDirectories = new List<Path>()
+					{
+						new Path("Folder"),
+						new Path("AnotherFolder/Sub"),
+					},
+					IncludeModules = new List<Path>()
+					{
+						new Path("../Other/bin/OtherModule1.mock.bmi"),
+						new Path("../OtherModule2.mock.bmi"),
+					},
+					PreprocessorDefinitions = new List<string>()
+					{
+						"DEBUG",
+						"AWESOME",
+					},
+					InterfacePartitionUnits = new List<InterfaceUnitCompileArguments>()
+					{
+						new InterfaceUnitCompileArguments()
+						{
+							SourceFile = new Path("TestFile1.cpp"),
+							TargetFile = new Path("obj/TestFile1.mock.obj"),
+							ModuleInterfaceTarget = new Path("obj/TestFile1.mock.bmi"),
+						},
+						new InterfaceUnitCompileArguments()
+						{
+							SourceFile = new Path("TestFile2.cpp"),
+							TargetFile = new Path("obj/TestFile2.mock.obj"),
+							ModuleInterfaceTarget = new Path("obj/TestFile2.mock.bmi"),
+						},
+					},
+					InterfaceUnit = new InterfaceUnitCompileArguments()
+					{
+						SourceFile = new Path("Public.cpp"),
+						TargetFile = new Path("obj/Public.mock.obj"),
+						IncludeModules = new List<Path>()
+						{
+							new Path("C:/target/obj/TestFile1.mock.bmi"),
+							new Path("C:/target/obj/TestFile2.mock.bmi"),
+						},
+						ModuleInterfaceTarget = new Path("obj/Public.mock.bmi"),
+					},
+					ImplementationUnits = new List<TranslationUnitCompileArguments>()
+					{
+						new TranslationUnitCompileArguments()
+						{
+							SourceFile = new Path("TestFile3.cpp"),
+							TargetFile = new Path("obj/TestFile3.mock.obj"),
+						},
+						new TranslationUnitCompileArguments()
+						{
+							SourceFile = new Path("TestFile4.cpp"),
+							TargetFile = new Path("obj/TestFile4.mock.obj"),
+						},
+					},
+				};
+
+				var expectedLinkArguments = new LinkArguments()
+				{
+					TargetFile = new Path("bin/Library.mock.lib"),
+					TargetType = LinkTarget.StaticLibrary,
+					TargetRootDirectory = new Path("C:/target/"),
+					ObjectFiles = new List<Path>()
+					{
+						new Path("obj/TestFile1.mock.obj"),
+						new Path("obj/TestFile2.mock.obj"),
+						new Path("obj/Public.mock.obj"),
+						new Path("obj/TestFile3.mock.obj"),
+						new Path("obj/TestFile4.mock.obj"),
+					},
+					LibraryFiles = new List<Path>(),
+				};
+
+				// Verify expected compiler calls
+				Assert.Equal(
+					new List<SharedCompileArguments>()
+					{
+						expectedCompileArguments,
+					},
+					compiler.GetCompileRequests());
+				Assert.Equal(
+					new List<LinkArguments>()
+					{
+						expectedLinkArguments,
+					},
+					compiler.GetLinkRequests());
+
+				// Verify build state
+				var expectedBuildOperations = new List<BuildOperation>()
+				{
+					new BuildOperation(
+						"MakeDir [./obj/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./obj/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("obj/"),
+						}),
+					new BuildOperation(
+						"MakeDir [./bin/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./bin/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("bin/"),
+						}),
+					new BuildOperation(
+						"Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
+						new Path("C:/target/"),
+						new Path("C:/copy.exe"),
+						"\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
+						new List<Path>()
+						{
+							new Path("obj/Public.mock.bmi"),
+						},
+						new List<Path>()
+						{
+							new Path("bin/Library.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompilePartition: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile1.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile1.mock.obj"),
+							new Path("obj/TestFile1.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompilePartition: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile2.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile2.mock.obj"),
+							new Path("obj/TestFile2.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompileModule: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("Public.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/Public.mock.obj"),
+							new Path("obj/Public.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile3.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile3.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile4.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile4.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockLink: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockLinker.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("InputFile.in"),
+						},
+						new List<Path>()
+						{
+							new Path("OutputFile.out"),
+						}),
+				};
+
+				Assert.Equal(
+					expectedBuildOperations,
+					result.BuildOperations);
+
+				Assert.Equal(
+					new List<Path>()
+					{
+						new Path("C:/target/bin/Library.mock.bmi"),
+					},
+					result.ModuleDependencies);
+
+				Assert.Equal(
+					new List<Path>()
+					{
+						new Path("../Other/bin/OtherModule1.mock.a"),
+						new Path("../OtherModule2.mock.a"),
+						new Path("C:/target/bin/Library.mock.lib"),
+					},
+					result.LinkDependencies);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.RuntimeDependencies);
+
+				Assert.Equal(
+					new Path(),
+					result.TargetFile);
+			}
+		}
+
+		[Fact]
+		public void Build_Library_ModuleInterfaceNoSource()
+		{
+			// Register the test process manager
+			var processManager = new MockProcessManager();
+
+			// Register the test listener
+			var testListener = new TestTraceListener();
+			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+			{
+				// Register the mock compiler
+				var compiler = new Mock.Compiler();
+
+				// Setup the build arguments
+				var arguments = new BuildArguments();
+				arguments.TargetName = "Library";
+				arguments.TargetType = BuildTargetType.StaticLibrary;
+				arguments.LanguageStandard = LanguageStandard.CPP20;
+				arguments.SourceRootDirectory = new Path("C:/source/");
+				arguments.TargetRootDirectory = new Path("C:/target/");
+				arguments.ObjectDirectory = new Path("obj/");
+				arguments.BinaryDirectory = new Path("bin/");
+				arguments.ModuleInterfaceSourceFile = new Path("Public.cpp");
+				arguments.SourceFiles = new List<Path>();
+				arguments.OptimizationLevel = BuildOptimizationLevel.Size;
+				arguments.IncludeDirectories = new List<Path>()
+				{
+					new Path("Folder"),
+					new Path("AnotherFolder/Sub"),
+				};
+				arguments.ModuleDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.bmi"),
+					new Path("../OtherModule2.mock.bmi"),
+				};
+				arguments.LinkDependencies = new List<Path>()
+				{
+					new Path("../Other/bin/OtherModule1.mock.a"),
+					new Path("../OtherModule2.mock.a"),
+				};
+
+				var uut = new BuildEngine(compiler);
+				var fileSystemState = new FileSystemState();
+				var readAccessList = new List<Path>();
+				var writeAccessList = new List<Path>();
+				var buildState = new BuildState(new ValueTable(), fileSystemState, readAccessList, writeAccessList);
+				var result = uut.Execute(buildState, arguments);
+
+				// Verify expected process manager requests
+				Assert.Equal(
+					new List<string>()
+					{
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+					},
+					processManager.GetRequests());
+
+				// Verify expected logs
+				Assert.Equal(
+					new List<string>()
+					{
+						"INFO: Generate Module Interface Unit Compile: ./Public.cpp",
+						"INFO: CoreLink",
+						"INFO: Linking target",
+						"INFO: Generate Link Operation: ./bin/Library.mock.lib",
+					},
+					testListener.GetMessages());
+
+				// Setup the shared arguments
+				var expectedCompileArguments = new SharedCompileArguments()
+				{
+					Standard = LanguageStandard.CPP20,
+					Optimize = OptimizationLevel.Size,
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
+					ObjectDirectory = new Path("obj/"),
+					IncludeDirectories = new List<Path>()
+					{
+						new Path("Folder"),
+						new Path("AnotherFolder/Sub"),
+					},
+					IncludeModules = new List<Path>()
+					{
+						new Path("../Other/bin/OtherModule1.mock.bmi"),
+						new Path("../OtherModule2.mock.bmi"),
+					},
+				};
+
+				var expectedCompileModuleArguments = new InterfaceUnitCompileArguments()
+				{
+					SourceFile = new Path("Public.cpp"),
+					TargetFile = new Path("obj/Public.mock.obj"),
+					ModuleInterfaceTarget = new Path("obj/Public.mock.bmi"),
+				};
+				expectedCompileArguments.InterfaceUnit = expectedCompileModuleArguments;
+
+				var expectedLinkArguments = new LinkArguments();
+				expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
+				expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+				expectedLinkArguments.ObjectFiles = new List<Path>()
+				{
+					new Path("obj/Public.mock.obj"),
+				};
+				expectedLinkArguments.LibraryFiles = new List<Path>();
+
+				// Verify expected compiler calls
+				Assert.Equal(
+					new List<SharedCompileArguments>()
+					{
+						expectedCompileArguments,
+					},
+					compiler.GetCompileRequests());
+				Assert.Equal(
+					new List<LinkArguments>()
+					{
+						expectedLinkArguments,
+					},
+					compiler.GetLinkRequests());
+
+				// Verify build state
+				var expectedBuildOperations = new List<BuildOperation>()
+				{
+					new BuildOperation(
+						"MakeDir [./obj/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./obj/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("obj/"),
+						}),
+					new BuildOperation(
+						"MakeDir [./bin/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./bin/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("bin/"),
+						}),
+					new BuildOperation(
+						"Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
+						new Path("C:/target/"),
+						new Path("C:/copy.exe"),
+						"\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
+						new List<Path>()
+						{
+							new Path("obj/Public.mock.bmi"),
+						},
+						new List<Path>()
+						{
+							new Path("bin/Library.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompileModule: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("Public.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/Public.mock.obj"),
+							new Path("obj/Public.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockLink: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockLinker.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("InputFile.in"),
+						},
+						new List<Path>()
+						{
+							new Path("OutputFile.out"),
+						}),
+				};
+
+				Assert.Equal(
+					expectedBuildOperations,
+					result.BuildOperations);
+
+				Assert.Equal(
+					new List<Path>()
+					{
+						new Path("C:/target/bin/Library.mock.bmi"),
+					},
+					result.ModuleDependencies);
+
+				Assert.Equal(
+					new List<Path>()
+					{
+						new Path("../Other/bin/OtherModule1.mock.a"),
+						new Path("../OtherModule2.mock.a"),
+						new Path("C:/target/bin/Library.mock.lib"),
+					},
+					result.LinkDependencies);
+
+				Assert.Equal(
+					new List<Path>(),
+					result.RuntimeDependencies);
+
+				Assert.Equal(
+					new Path(),
+					result.TargetFile);
+			}
+		}
+	}
 }

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core.UnitTests/BuildEngineUnitTests.cs
@@ -1133,10 +1133,20 @@ namespace Soup.Build.Cpp.Compiler.UnitTests
 				arguments.TargetRootDirectory = new Path("C:/target/");
 				arguments.ObjectDirectory = new Path("obj/");
 				arguments.BinaryDirectory = new Path("bin/");
-				arguments.ModuleInterfacePartitionSourceFiles = new List<Path>()
+				arguments.ModuleInterfacePartitionSourceFiles = new List<PartitionSourceFile>()
 				{
-					new Path("TestFile1.cpp"),
-					new Path("TestFile2.cpp"),
+					new PartitionSourceFile()
+					{
+						File = new Path("TestFile1.cpp"),
+					},
+					new PartitionSourceFile()
+					{
+						File = new Path("TestFile2.cpp"),
+						Imports = new List<Path>()
+						{
+							new Path("TestFile1.cpp"),
+						}
+					},
 				};
 				arguments.ModuleInterfaceSourceFile = new Path("Public.cpp");
 				arguments.SourceFiles = new List<Path>()
@@ -1233,6 +1243,10 @@ namespace Soup.Build.Cpp.Compiler.UnitTests
 						{
 							SourceFile = new Path("TestFile2.cpp"),
 							TargetFile = new Path("obj/TestFile2.mock.obj"),
+							IncludeModules = new List<Path>()
+							{
+								new Path("C:/target/obj/TestFile1.mock.bmi")
+							},
 							ModuleInterfaceTarget = new Path("obj/TestFile2.mock.bmi"),
 						},
 					},

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildArguments.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildArguments.cs
@@ -109,6 +109,13 @@ namespace Soup.Build.Cpp.Compiler
 		public Path BinaryDirectory { get; set; } = new Path();
 
 		/// <summary>
+		/// Gets or sets the list of module interface partition source files
+		/// Note: These files can be plain old translation units 
+		/// or they can be module implementation units
+		/// </summary>
+		public IReadOnlyList<Path> ModuleInterfacePartitionSourceFiles { get; set; } = new List<Path>();
+
+		/// <summary>
 		/// Gets or sets the single module interface source file
 		/// </summary>
 		public Path ModuleInterfaceSourceFile { get; set; } = new Path();

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildArguments.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildArguments.cs
@@ -64,6 +64,15 @@ namespace Soup.Build.Cpp.Compiler
 	}
 
 	/// <summary>
+	/// The partition source file definition
+	/// </summary>
+	public class PartitionSourceFile
+	{
+		public Path File { get; set; } = new Path();
+		public IReadOnlyList<Path> Imports { get; set; } = new List<Path>();
+	}
+
+	/// <summary>
 	/// The set of build arguments
 	/// </summary>
 	public class BuildArguments
@@ -113,7 +122,7 @@ namespace Soup.Build.Cpp.Compiler
 		/// Note: These files can be plain old translation units 
 		/// or they can be module implementation units
 		/// </summary>
-		public IReadOnlyList<Path> ModuleInterfacePartitionSourceFiles { get; set; } = new List<Path>();
+		public IReadOnlyList<PartitionSourceFile> ModuleInterfacePartitionSourceFiles { get; set; } = new List<PartitionSourceFile>();
 
 		/// <summary>
 		/// Gets or sets the single module interface source file

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildEngine.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildEngine.cs
@@ -113,17 +113,26 @@ namespace Soup.Build.Cpp.Compiler
 				var allPartitionInterfaces = new List<Path>();
 				foreach (var file in arguments.ModuleInterfacePartitionSourceFiles)
 				{
-					buildState.LogTrace(TraceLevel.Information, "Generate Module Interface Partition Compile Operation: " + file.ToString());
+					buildState.LogTrace(TraceLevel.Information, "Generate Module Interface Partition Compile Operation: " + file.File.ToString());
 
 					var objectModuleInterfaceFile =
 						arguments.ObjectDirectory +
-						new Path(file.GetFileName());
+						new Path(file.File.GetFileName());
 					objectModuleInterfaceFile.SetFileExtension(_compiler.ModuleFileExtension);
+
+					var partitionImports = new List<Path>();
+					foreach (var import in file.Imports)
+					{
+						var importInterface = arguments.ObjectDirectory + new Path(import.GetFileName());
+						importInterface.SetFileExtension(_compiler.ModuleFileExtension);
+						partitionImports.Add(arguments.TargetRootDirectory + importInterface);
+					}
 
 					var compileFileArguments = new InterfaceUnitCompileArguments()
 					{
-						SourceFile = file,
-						TargetFile = arguments.ObjectDirectory + new Path(file.GetFileName()),
+						SourceFile = file.File,
+						TargetFile = arguments.ObjectDirectory + new Path(file.File.GetFileName()),
+						IncludeModules = partitionImports,
 						ModuleInterfaceTarget = objectModuleInterfaceFile,
 					};
 
@@ -341,7 +350,7 @@ namespace Soup.Build.Cpp.Compiler
 			// Add the partition object files
 			foreach (var sourceFile in arguments.ModuleInterfacePartitionSourceFiles)
 			{
-				var objectFile = arguments.ObjectDirectory + new Path(sourceFile.GetFileName());
+				var objectFile = arguments.ObjectDirectory + new Path(sourceFile.File.GetFileName());
 				objectFile.SetFileExtension(_compiler.ObjectFileExtension);
 				objectFiles.Add(objectFile);
 			}

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildEngine.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/BuildEngine.cs
@@ -142,6 +142,13 @@ namespace Soup.Build.Cpp.Compiler
 					allPartitionInterfaces.Add(arguments.TargetRootDirectory + objectModuleInterfaceFile);
 				}
 
+				// Add all partition unit interface files as module dependencies since MSVC does not
+				// combine the interfaces into the final interface unit
+				foreach (var module in allPartitionInterfaces)
+				{
+					result.ModuleDependencies.Add(module);
+				}
+
 				compileArguments.InterfacePartitionUnits = compileInterfacePartitionUnits;
 
 				// Compile the module interface unit if present

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/CompileArguments.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/CompileArguments.cs
@@ -71,6 +71,11 @@ namespace Soup.Build.Cpp.Compiler
 		/// </summary>
 		public Path TargetFile { get; set; } = new Path();
 
+		/// <summary>
+		/// Gets or sets the list of modules
+		/// </summary>
+		public IReadOnlyList<Path> IncludeModules { get; init; } = new List<Path>();
+
 		public override bool Equals(object? obj) => this.Equals(obj as TranslationUnitCompileArguments);
 
 		public bool Equals(TranslationUnitCompileArguments? rhs)
@@ -84,7 +89,8 @@ namespace Soup.Build.Cpp.Compiler
 
 			// Return true if the fields match.
 			return this.SourceFile == rhs.SourceFile &&
-				this.TargetFile == rhs.TargetFile;
+				this.TargetFile == rhs.TargetFile &&
+				Enumerable.SequenceEqual(IncludeModules, rhs.IncludeModules);
 		}
 
 		public override int GetHashCode() => (SourceFile, TargetFile).GetHashCode();
@@ -103,6 +109,11 @@ namespace Soup.Build.Cpp.Compiler
 		}
 
 		public static bool operator !=(TranslationUnitCompileArguments? lhs, TranslationUnitCompileArguments? rhs) => !(lhs == rhs);
+
+		public override string ToString()
+		{
+			return $"TranslationUnitCompileArguments {{ SourceFile=\"{SourceFile}\", TargetFile=\"{TargetFile}\", IncludeModules=[{string.Join(",", IncludeModules)}] }}";
+		}
 	}
 
 	/// <summary>
@@ -129,10 +140,11 @@ namespace Soup.Build.Cpp.Compiler
 			// Return true if the fields match.
 			return this.SourceFile == rhs.SourceFile &&
 				this.TargetFile == rhs.TargetFile && 
+				Enumerable.SequenceEqual(IncludeModules, rhs.IncludeModules) &&
 				this.ModuleInterfaceTarget == rhs.ModuleInterfaceTarget;
 		}
 
-		public override int GetHashCode() => (SourceFile, TargetFile).GetHashCode();
+		public override int GetHashCode() => (SourceFile, TargetFile, ModuleInterfaceTarget).GetHashCode();
 
 		public static bool operator ==(InterfaceUnitCompileArguments? lhs, InterfaceUnitCompileArguments? rhs)
 		{
@@ -151,7 +163,7 @@ namespace Soup.Build.Cpp.Compiler
 
 		public override string ToString()
 		{
-			return $"InterfaceUnitCompileArguments {{ SourceFile=\"{SourceFile}\", TargetFile=\"{TargetFile}\", ModuleInterfaceTarget=\"{ModuleInterfaceTarget}\" }}";
+			return $"InterfaceUnitCompileArguments {{ SourceFile=\"{SourceFile}\", TargetFile=\"{TargetFile}\", IncludeModules=[{string.Join(",", IncludeModules)}], ModuleInterfaceTarget=\"{ModuleInterfaceTarget}\" }}";
 		}
 	}
 
@@ -204,6 +216,11 @@ namespace Soup.Build.Cpp.Compiler
 		/// Gets or sets a value indicating whether to generate source debug information
 		/// </summary>
 		public bool GenerateSourceDebugInfo { get; init; }
+
+		/// <summary>
+		/// Gets or sets the list of interface partition translation units to compile
+		/// </summary>
+		public IReadOnlyList<InterfaceUnitCompileArguments> InterfacePartitionUnits { get; set; } = new List<InterfaceUnitCompileArguments>();
 
 		/// <summary>
 		/// Gets or sets the single optional interface unit to compile
@@ -261,6 +278,7 @@ namespace Soup.Build.Cpp.Compiler
 				Enumerable.SequenceEqual(this.IncludeDirectories, rhs.IncludeDirectories) &&
 				Enumerable.SequenceEqual(this.IncludeModules, rhs.IncludeModules) &&
 				this.GenerateSourceDebugInfo == rhs.GenerateSourceDebugInfo &&
+				Enumerable.SequenceEqual(this.InterfacePartitionUnits, rhs.InterfacePartitionUnits) &&
 				this.InterfaceUnit == rhs.InterfaceUnit &&
 				this.ResourceFile == rhs.ResourceFile &&
 				Enumerable.SequenceEqual(this.ImplementationUnits, rhs.ImplementationUnits) &&
@@ -289,7 +307,7 @@ namespace Soup.Build.Cpp.Compiler
 
 		public override string ToString()
 		{
-			return $"SharedCompileArguments {{ Standard={Standard}, Optimize={Optimize}, SourceRootDirectory=\"{SourceRootDirectory}\", TargetRootDirectory=\"{TargetRootDirectory}\", ObjectDirectory=\"{ObjectDirectory}\", PreprocessorDefinitions=[{string.Join(",", PreprocessorDefinitions)}], IncludeDirectories=[{string.Join(",", IncludeDirectories)}], IncludeModules=[{string.Join(",", IncludeModules)}], GenerateSourceDebugInfo=\"{GenerateSourceDebugInfo}\", InterfaceUnit={InterfaceUnit}, ImplementationUnits=[{string.Join(",", ImplementationUnits)}], ResourceFile={ResourceFile}, EnableWarningsAsErrors=\"{EnableWarningsAsErrors}\", DisabledWarnings=[{string.Join(",", DisabledWarnings)}], EnabledWarnings=[{string.Join(",", EnabledWarnings)}], CustomProperties=[{string.Join(",", CustomProperties)}]}}";
+			return $"SharedCompileArguments {{ Standard={Standard}, Optimize={Optimize}, SourceRootDirectory=\"{SourceRootDirectory}\", TargetRootDirectory=\"{TargetRootDirectory}\", ObjectDirectory=\"{ObjectDirectory}\", PreprocessorDefinitions=[{string.Join(",", PreprocessorDefinitions)}], IncludeDirectories=[{string.Join(",", IncludeDirectories)}], IncludeModules=[{string.Join(",", IncludeModules)}], GenerateSourceDebugInfo=\"{GenerateSourceDebugInfo}\", InterfacePartitionUnits=[{string.Join(",", InterfacePartitionUnits)}], InterfaceUnit={InterfaceUnit}, ImplementationUnits=[{string.Join(",", ImplementationUnits)}], ResourceFile={ResourceFile}, EnableWarningsAsErrors=\"{EnableWarningsAsErrors}\", DisabledWarnings=[{string.Join(",", DisabledWarnings)}], EnabledWarnings=[{string.Join(",", EnabledWarnings)}], CustomProperties=[{string.Join(",", CustomProperties)}]}}";
 		}
 	}
 

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/LinkArguments.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/LinkArguments.cs
@@ -131,9 +131,9 @@ namespace Soup.Build.Cpp.Compiler
 
 		public static bool operator !=(LinkArguments? lhs, LinkArguments? rhs) => !(lhs == rhs);
 
-        public override string ToString()
-        {
+		public override string ToString()
+		{
 			return $"LinkArguments {{ TargetFile=\"{TargetFile}\", TargetType={TargetType}, ImplementationFile=\"{ImplementationFile}\", TargetRootDirectory=\"{TargetRootDirectory}\", TargetArchitecture=\"{TargetArchitecture}\", ObjectFiles=[{string.Join(",", ObjectFiles)}], LibraryFiles=[{string.Join(",", LibraryFiles)}], ExternalLibraryFiles=[{string.Join(",", ExternalLibraryFiles)}], LibraryPaths=[{string.Join(",", LibraryPaths)}], GenerateSourceDebugInfo={GenerateSourceDebugInfo} }}";
 		}
-    }
+	}
 }

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/MockCompiler.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/Core/MockCompiler.cs
@@ -78,6 +78,26 @@ namespace Soup.Build.Cpp.Compiler.Mock
 			_compileRequests.Add(arguments);
 
 			var result = new List<BuildOperation>();
+
+			foreach (var fileArguments in arguments.InterfacePartitionUnits)
+			{
+				result.Add(
+					new BuildOperation(
+						$"MockCompilePartition: {_compileRequests.Count}",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							fileArguments.SourceFile,
+						},
+						new List<Path>()
+						{
+							fileArguments.TargetFile,
+							fileArguments.ModuleInterfaceTarget,
+						}));
+			}
+
 			if (!ReferenceEquals(arguments.InterfaceUnit, null))
 			{
 				result.Add(
@@ -88,11 +108,12 @@ namespace Soup.Build.Cpp.Compiler.Mock
 						"Arguments",
 						new List<Path>()
 						{
-							new Path("InputFile.in"),
+							arguments.InterfaceUnit.SourceFile,
 						},
 						new List<Path>()
 						{
-							new Path("OutputFile.out"),
+							arguments.InterfaceUnit.TargetFile,
+							arguments.InterfaceUnit.ModuleInterfaceTarget,
 						}));
 			}
 

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerArgumentBuilderUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerArgumentBuilderUnitTests.cs
@@ -385,6 +385,35 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 		}
 
 		[Fact]
+		public void BuildPartitionUnitCompilerArguments()
+		{
+			var targetRootDirectory = new Path("C:/target/");
+			var arguments = new InterfaceUnitCompileArguments();
+			arguments.SourceFile = new Path("module.cpp");
+			arguments.TargetFile = new Path("module.obj");
+			arguments.ModuleInterfaceTarget = new Path("module.ifc");
+
+			var responseFile = new Path("ResponseFile.txt");
+
+			var actualArguments = ArgumentBuilder.BuildPartitionUnitCompilerArguments(
+				targetRootDirectory,
+				arguments,
+				responseFile);
+
+			var expectedArguments = new List<string>()
+			{
+				"@./ResponseFile.txt",
+				"./module.cpp",
+				"/Fo\"C:/target/module.obj\"",
+				"/interface",
+				"/ifcOutput",
+				"\"C:/target/module.ifc\"",
+			};
+
+			Assert.Equal(expectedArguments, actualArguments);
+		}
+
+		[Fact]
 		public void BuildInterfaceUnitCompilerArguments()
 		{
 			var targetRootDirectory = new Path("C:/target/");

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerArgumentBuilderUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC.UnitTests/CompilerArgumentBuilderUnitTests.cs
@@ -450,13 +450,18 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 			{
 				SourceFile = new Path("module.cpp"),
 				TargetFile = new Path("module.obj"),
+				IncludeModules = new List<Path>()
+				{
+					new Path("Module1.ifc"),
+					new Path("Module2.ifc"),
+				},
 			};
 
 			var responseFile = new Path("ResponseFile.txt");
 			var internalModules = new List<Path>()
 			{
-				new Path("Module1.ifc"),
-				new Path("Module2.ifc"),
+				new Path("Module3.ifc"),
+				new Path("Module4.ifc"),
 			};
 
 			var actualArguments = ArgumentBuilder.BuildTranslationUnitCompilerArguments(
@@ -472,6 +477,10 @@ namespace Soup.Build.Cpp.Compiler.MSVC.UnitTests
 				"\"./Module1.ifc\"",
 				"/reference",
 				"\"./Module2.ifc\"",
+				"/reference",
+				"\"./Module3.ifc\"",
+				"/reference",
+				"\"./Module4.ifc\"",
 				"./module.cpp",
 				"/Fo\"C:/target/module.obj\"",
 			};

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/ArgumentBuilder.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/ArgumentBuilder.cs
@@ -271,6 +271,46 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 			return commandArguments;
 		}
 
+		public static IList<string> BuildPartitionUnitCompilerArguments(
+			Path targetRootDirectory,
+			InterfaceUnitCompileArguments arguments,
+			Path responseFile)
+		{
+			// Build the arguments for a standard translation unit
+			var commandArguments = new List<string>();
+
+			// Add the response file
+			commandArguments.Add("@" + responseFile.ToString());
+
+			// Add the module references as input
+			foreach (var moduleFile in arguments.IncludeModules)
+			{
+				AddFlag(commandArguments, "reference");
+				AddValueWithQuotes(commandArguments, moduleFile.ToString());
+			}
+
+			// Add the source file as input
+			commandArguments.Add(arguments.SourceFile.ToString());
+
+			// Add the target file as outputs
+			var absoluteTargetFile = targetRootDirectory + arguments.TargetFile;
+			AddFlagValueWithQuotes(
+				commandArguments,
+				Compiler_ArgumentParameter_ObjectFile,
+				absoluteTargetFile.ToString());
+
+			// Add the unique arguments for an partition unit
+			AddFlag(commandArguments, "interface");
+
+			// Specify the module interface file output
+			AddFlag(commandArguments, "ifcOutput");
+
+			var absoluteModuleInterfaceFile = targetRootDirectory + arguments.ModuleInterfaceTarget;
+			AddValueWithQuotes(commandArguments, absoluteModuleInterfaceFile.ToString());
+
+			return commandArguments;
+		}
+
 		public static IList<string> BuildTranslationUnitCompilerArguments(
 			Path targetRootDirectory,
 			TranslationUnitCompileArguments arguments,

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/ArgumentBuilder.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/ArgumentBuilder.cs
@@ -242,6 +242,13 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 			// Add the response file
 			commandArguments.Add("@" + responseFile.ToString());
 
+			// Add the module references as input
+			foreach (var moduleFile in arguments.IncludeModules)
+			{
+				AddFlag(commandArguments, "reference");
+				AddValueWithQuotes(commandArguments, moduleFile.ToString());
+			}
+
 			// Add the source file as input
 			commandArguments.Add(arguments.SourceFile.ToString());
 
@@ -275,6 +282,13 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 
 			// Add the response file
 			commandArguments.Add("@" + responseFile.ToString());
+
+			// Add the internal module references as input
+			foreach (var moduleFile in arguments.IncludeModules)
+			{
+				AddFlag(commandArguments, "reference");
+				AddValueWithQuotes(commandArguments, moduleFile.ToString());
+			}
 
 			// Add the internal module references as input
 			foreach (var moduleFile in internalModules)

--- a/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/Compiler.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Compiler/MSVC/Compiler.cs
@@ -128,7 +128,7 @@ namespace Soup.Build.Cpp.Compiler.MSVC
 				};
 
 				// Build the unique arguments for this translation unit
-				var commandArguments = ArgumentBuilder.BuildInterfaceUnitCompilerArguments(
+				var commandArguments = ArgumentBuilder.BuildPartitionUnitCompilerArguments(
 					arguments.TargetRootDirectory,
 					partitionUnitArguments,
 					absoluteResponseFile);

--- a/Source/GenerateSharp/Extensions/Cpp/Extension.UnitTests/Tasks/BuildTaskUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension.UnitTests/Tasks/BuildTaskUnitTests.cs
@@ -900,8 +900,15 @@ namespace Soup.Build.Cpp.UnitTests
 				buildTable.Add("BinaryDirectory", new Value("bin/"));
 				buildTable.Add("ModuleInterfacePartitionSourceFiles", new Value(new ValueList()
 				{
-					new Value("TestFile1.cpp"),
-					new Value("TestFile2.cpp"),
+					new Value(new ValueTable()
+					{
+						{ "Source", new Value("TestFile1.cpp") },
+					}),
+					new Value(new ValueTable()
+					{
+						{ "Source", new Value("TestFile2.cpp") },
+						{ "Imports", new Value(new ValueList() { new Value("TestFile1.cpp"), }) },
+					}),
 				}));
 				buildTable.Add("ModuleInterfaceSourceFile", new Value("Public.cpp"));
 				buildTable.Add("Source", new Value(new ValueList()
@@ -1003,6 +1010,10 @@ namespace Soup.Build.Cpp.UnitTests
 						{
 							SourceFile = new Path("TestFile2.cpp"),
 							TargetFile = new Path("obj/TestFile2.mock.obj"),
+							IncludeModules = new List<Path>()
+							{
+								new Path("C:/target/obj/TestFile1.mock.bmi"),
+							},
 							ModuleInterfaceTarget = new Path("obj/TestFile2.mock.bmi"),
 						},
 					},

--- a/Source/GenerateSharp/Extensions/Cpp/Extension.UnitTests/Tasks/BuildTaskUnitTests.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension.UnitTests/Tasks/BuildTaskUnitTests.cs
@@ -151,7 +151,7 @@ namespace Soup.Build.Cpp.UnitTests
 						new List<Path>(),
 						new List<Path>()
 						{
-							new Path("./obj/"),
+							new Path("obj/"),
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
@@ -161,7 +161,7 @@ namespace Soup.Build.Cpp.UnitTests
 						new List<Path>(),
 						new List<Path>()
 						{
-							new Path("./bin/"),
+							new Path("bin/"),
 						}),
 					new BuildOperation(
 						"MockCompile: 1",
@@ -742,10 +742,10 @@ namespace Soup.Build.Cpp.UnitTests
 				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
 				expectedLinkArguments.ObjectFiles = new List<Path>()
 				{
+					new Path("obj/Public.mock.obj"),
 					new Path("obj/TestFile1.mock.obj"),
 					new Path("obj/TestFile2.mock.obj"),
 					new Path("obj/TestFile3.mock.obj"),
-					new Path("obj/Public.mock.obj"),
 				};
 				expectedLinkArguments.LibraryFiles = new List<Path>();
 
@@ -774,7 +774,7 @@ namespace Soup.Build.Cpp.UnitTests
 						new List<Path>(),
 						new List<Path>()
 						{
-							new Path("./obj/"),
+							new Path("obj/"),
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
@@ -784,7 +784,7 @@ namespace Soup.Build.Cpp.UnitTests
 						new List<Path>(),
 						new List<Path>()
 						{
-							new Path("./bin/"),
+							new Path("bin/"),
 						}),
 					new BuildOperation(
 						"Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
@@ -793,11 +793,11 @@ namespace Soup.Build.Cpp.UnitTests
 						"\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
 						new List<Path>()
 						{
-							new Path("./obj/Public.mock.bmi"),
+							new Path("obj/Public.mock.bmi"),
 						},
 						new List<Path>()
 						{
-							new Path("./bin/Library.mock.bmi"),
+							new Path("bin/Library.mock.bmi"),
 						}),
 					new BuildOperation(
 						"MockCompileModule: 1",
@@ -806,11 +806,12 @@ namespace Soup.Build.Cpp.UnitTests
 						"Arguments",
 						new List<Path>()
 						{
-							new Path("InputFile.in"),
+							new Path("Public.cpp"),
 						},
 						new List<Path>()
 						{
-							new Path("OutputFile.out"),
+							new Path("obj/Public.mock.obj"),
+							new Path("obj/Public.mock.bmi"),
 						}),
 					new BuildOperation(
 						"MockCompile: 1",
@@ -850,6 +851,319 @@ namespace Soup.Build.Cpp.UnitTests
 						new List<Path>()
 						{
 							new Path("obj/TestFile3.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockLink: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockLinker.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("InputFile.in"),
+						},
+						new List<Path>()
+						{
+							new Path("OutputFile.out"),
+						}),
+				};
+
+				Assert.Equal(
+					expectedBuildOperations,
+					buildState.GetBuildOperations());
+			}
+		}
+
+		[Fact]
+		public void Build_Library_ModuleInterface_WithPartitions()
+		{
+			// Register the test process manager
+			var processManager = new MockProcessManager();
+
+			// Register the test listener
+			var testListener = new TestTraceListener();
+			using (var scopedTraceListener = new ScopedTraceListenerRegister(testListener))
+			using (var scopedProcesManager = new ScopedSingleton<IProcessManager>(processManager))
+			{
+				// Setup the input build state
+				var buildState = new MockBuildState();
+				var state = buildState.ActiveState;
+
+				// Setup build table
+				var buildTable = new ValueTable();
+				state.Add("Build", new Value(buildTable));
+				buildTable.Add("TargetName", new Value("Library"));
+				buildTable.Add("TargetType", new Value((long)BuildTargetType.StaticLibrary));
+				buildTable.Add("LanguageStandard", new Value((long)LanguageStandard.CPP20));
+				buildTable.Add("SourceRootDirectory", new Value("C:/source/"));
+				buildTable.Add("TargetRootDirectory", new Value("C:/target/"));
+				buildTable.Add("ObjectDirectory", new Value("obj/"));
+				buildTable.Add("BinaryDirectory", new Value("bin/"));
+				buildTable.Add("ModuleInterfacePartitionSourceFiles", new Value(new ValueList()
+				{
+					new Value("TestFile1.cpp"),
+					new Value("TestFile2.cpp"),
+				}));
+				buildTable.Add("ModuleInterfaceSourceFile", new Value("Public.cpp"));
+				buildTable.Add("Source", new Value(new ValueList()
+				{
+					new Value("TestFile3.cpp"),
+					new Value("TestFile4.cpp"),
+				}));
+				buildTable.Add("IncludeDirectories", new Value(new ValueList()
+				{
+					new Value("Folder"),
+					new Value("AnotherFolder/Sub"),
+				}));
+				buildTable.Add("ModuleDependencies", new Value(new ValueList()
+				{
+					new Value("../Other/bin/OtherModule1.mock.bmi"),
+					new Value("../OtherModule2.mock.bmi"),
+				}));
+				buildTable.Add("OptimizationLevel", new Value((long)BuildOptimizationLevel.None));
+				buildTable.Add("PreprocessorDefinitions", new Value(new ValueList()
+				{
+					new Value("DEBUG"),
+					new Value("AWESOME"),
+				}));
+
+				// Setup parameters table
+				var parametersTable = new ValueTable();
+				state.Add("Parameters", new Value(parametersTable));
+				parametersTable.Add("Architecture", new Value("x64"));
+				parametersTable.Add("Compiler", new Value("MOCK"));
+
+				// Register the mock compiler
+				var compiler = new Compiler.Mock.Compiler();
+				var compilerFactory = new Dictionary<string, Func<IValueTable, ICompiler>>();
+				compilerFactory.Add("MOCK", (IValueTable state) => { return compiler; });
+
+				var factory = new ValueFactory();
+				var uut = new BuildTask(buildState, factory, compilerFactory);
+
+				uut.Execute();
+
+				// Verify expected process manager requests
+				Assert.Equal(
+					new List<string>()
+					{
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+						"GetCurrentProcessFileName",
+					},
+					processManager.GetRequests());
+
+				// Verify expected logs
+				Assert.Equal(
+					new List<string>()
+					{
+						"INFO: Generate Module Interface Partition Compile Operation: ./TestFile1.cpp",
+						"INFO: Generate Module Interface Partition Compile Operation: ./TestFile2.cpp",
+						"INFO: Generate Module Interface Unit Compile: ./Public.cpp",
+						"INFO: Generate Compile Operation: ./TestFile3.cpp",
+						"INFO: Generate Compile Operation: ./TestFile4.cpp",
+						"INFO: CoreLink",
+						"INFO: Linking target",
+						"INFO: Generate Link Operation: ./bin/Library.mock.lib",
+						"INFO: Build Generate Done",
+					},
+					testListener.GetMessages());
+
+				// Setup the shared arguments
+				var expectedCompileArguments = new SharedCompileArguments()
+				{
+					Standard = LanguageStandard.CPP20,
+					Optimize = OptimizationLevel.None,
+					SourceRootDirectory = new Path("C:/source/"),
+					TargetRootDirectory = new Path("C:/target/"),
+					ObjectDirectory = new Path("obj/"),
+					IncludeDirectories = new List<Path>()
+					{
+						new Path("Folder"),
+						new Path("AnotherFolder/Sub"),
+					},
+					IncludeModules = new List<Path>()
+					{
+						new Path("../Other/bin/OtherModule1.mock.bmi"),
+						new Path("../OtherModule2.mock.bmi"),
+					},
+					PreprocessorDefinitions = new List<string>()
+					{
+						"DEBUG",
+						"AWESOME",
+					},
+					InterfacePartitionUnits = new List<InterfaceUnitCompileArguments>()
+					{
+						new InterfaceUnitCompileArguments()
+						{
+							SourceFile = new Path("TestFile1.cpp"),
+							TargetFile = new Path("obj/TestFile1.mock.obj"),
+							ModuleInterfaceTarget = new Path("obj/TestFile1.mock.bmi"),
+						},
+						new InterfaceUnitCompileArguments()
+						{
+							SourceFile = new Path("TestFile2.cpp"),
+							TargetFile = new Path("obj/TestFile2.mock.obj"),
+							ModuleInterfaceTarget = new Path("obj/TestFile2.mock.bmi"),
+						},
+					},
+					InterfaceUnit = new InterfaceUnitCompileArguments()
+					{
+						ModuleInterfaceTarget = new Path("obj/Public.mock.bmi"),
+						SourceFile = new Path("Public.cpp"),
+						IncludeModules = new List<Path>()
+						{
+							new Path("C:/target/obj/TestFile1.mock.bmi"),
+							new Path("C:/target/obj/TestFile2.mock.bmi"),
+						},
+						TargetFile = new Path("obj/Public.mock.obj"),
+					},
+					ImplementationUnits = new List<TranslationUnitCompileArguments>()
+					{
+						new TranslationUnitCompileArguments()
+						{
+							SourceFile = new Path("TestFile3.cpp"),
+							TargetFile = new Path("obj/TestFile3.mock.obj"),
+						},
+						new TranslationUnitCompileArguments()
+						{
+							SourceFile = new Path("TestFile4.cpp"),
+							TargetFile = new Path("obj/TestFile4.mock.obj"),
+						},
+					},
+				};
+
+				var expectedLinkArguments = new LinkArguments();
+				expectedLinkArguments.TargetFile = new Path("bin/Library.mock.lib");
+				expectedLinkArguments.TargetType = LinkTarget.StaticLibrary;
+				expectedLinkArguments.TargetArchitecture = "x64";
+				expectedLinkArguments.TargetRootDirectory = new Path("C:/target/");
+				expectedLinkArguments.ObjectFiles = new List<Path>()
+				{
+					new Path("obj/TestFile1.mock.obj"),
+					new Path("obj/TestFile2.mock.obj"),
+					new Path("obj/Public.mock.obj"),
+					new Path("obj/TestFile3.mock.obj"),
+					new Path("obj/TestFile4.mock.obj"),
+				};
+				expectedLinkArguments.LibraryFiles = new List<Path>();
+
+				// Verify expected compiler calls
+				Assert.Equal(
+					new List<SharedCompileArguments>()
+					{
+						expectedCompileArguments,
+					},
+					compiler.GetCompileRequests());
+				Assert.Equal(
+					new List<LinkArguments>()
+					{
+						expectedLinkArguments,
+					},
+					compiler.GetLinkRequests());
+
+				// Verify build state
+				var expectedBuildOperations = new List<BuildOperation>()
+				{
+					new BuildOperation(
+						"MakeDir [./obj/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./obj/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("obj/"),
+						}),
+					new BuildOperation(
+						"MakeDir [./bin/]",
+						new Path("C:/target/"),
+						new Path("C:/mkdir.exe"),
+						"\"./bin/\"",
+						new List<Path>(),
+						new List<Path>()
+						{
+							new Path("bin/"),
+						}),
+					new BuildOperation(
+						"Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
+						new Path("C:/target/"),
+						new Path("C:/copy.exe"),
+						"\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
+						new List<Path>()
+						{
+							new Path("obj/Public.mock.bmi"),
+						},
+						new List<Path>()
+						{
+							new Path("bin/Library.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompilePartition: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile1.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile1.mock.obj"),
+							new Path("obj/TestFile1.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompilePartition: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile2.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile2.mock.obj"),
+							new Path("obj/TestFile2.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompileModule: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("Public.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/Public.mock.obj"),
+							new Path("obj/Public.mock.bmi"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile3.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile3.mock.obj"),
+						}),
+					new BuildOperation(
+						"MockCompile: 1",
+						new Path("MockWorkingDirectory"),
+						new Path("MockCompiler.exe"),
+						"Arguments",
+						new List<Path>()
+						{
+							new Path("TestFile4.cpp"),
+						},
+						new List<Path>()
+						{
+							new Path("obj/TestFile4.mock.obj"),
 						}),
 					new BuildOperation(
 						"MockLink: 1",
@@ -1021,7 +1335,7 @@ namespace Soup.Build.Cpp.UnitTests
 						new List<Path>(),
 						new List<Path>()
 						{
-							new Path("./obj/"),
+							new Path("obj/"),
 						}),
 					new BuildOperation(
 						"MakeDir [./bin/]",
@@ -1031,7 +1345,7 @@ namespace Soup.Build.Cpp.UnitTests
 						new List<Path>(),
 						new List<Path>()
 						{
-							new Path("./bin/"),
+							new Path("bin/"),
 						}),
 					new BuildOperation(
 						"Copy [./obj/Public.mock.bmi] -> [./bin/Library.mock.bmi]",
@@ -1040,11 +1354,11 @@ namespace Soup.Build.Cpp.UnitTests
 						"\"./obj/Public.mock.bmi\" \"./bin/Library.mock.bmi\"",
 						new List<Path>()
 						{
-							new Path("./obj/Public.mock.bmi"),
+							new Path("obj/Public.mock.bmi"),
 						},
 						new List<Path>()
 						{
-							new Path("./bin/Library.mock.bmi"),
+							new Path("bin/Library.mock.bmi"),
 						}),
 					new BuildOperation(
 						"MockCompileModule: 1",
@@ -1053,11 +1367,12 @@ namespace Soup.Build.Cpp.UnitTests
 						"Arguments",
 						new List<Path>()
 						{
-							new Path("InputFile.in"),
+							new Path("Public.cpp"),
 						},
 						new List<Path>()
 						{
-							new Path("OutputFile.out"),
+							new Path("obj/Public.mock.obj"),
+							new Path("obj/Public.mock.bmi"),
 						}),
 					 new BuildOperation(
 						"MockLink: 1",

--- a/Source/GenerateSharp/Extensions/Cpp/Extension/PackageLock.toml
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension/PackageLock.toml
@@ -2,8 +2,8 @@
 "C#" = [
 	{ Name = "Soup.Cpp", Version = "./" },
 	{ Name = "Opal", Version = "Opal@1.0.1" },
-	{ Name = "Soup.Build", Version = "Soup.Build@0.1.3" },
-	{ Name = "Soup.Build.Extensions", Version = "Soup.Build.Extensions@0.1.8" },
-	{ Name = "Soup.Cpp.Compiler", Version = "Soup.Cpp.Compiler@0.1.8" },
-	{ Name = "Soup.Cpp.Compiler.MSVC", Version = "Soup.Cpp.Compiler.MSVC@0.1.10" },
+	{ Name = "Soup.Build", Version = "../../../Build/" },
+	{ Name = "Soup.Build.Extensions", Version = "../../../Build.Extensions/" },
+	{ Name = "Soup.Cpp.Compiler", Version = "../Compiler/Core/" },
+	{ Name = "Soup.Cpp.Compiler.MSVC", Version = "../Compiler/MSVC/" },
 ]

--- a/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/BuildTask.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/BuildTask.cs
@@ -83,6 +83,11 @@ namespace Soup.Build.Cpp
 				arguments.ResourceFile = new Path(resourcesFile.AsString());
 			}
 
+			if (buildTable.TryGetValue("ModuleInterfacePartitionSourceFiles", out var moduleInterfacePartitionSourceFiles))
+			{
+				arguments.ModuleInterfacePartitionSourceFiles = moduleInterfacePartitionSourceFiles.AsList().Select(value => new Path(value.AsString())).ToList();
+			}
+
 			if (buildTable.TryGetValue("ModuleInterfaceSourceFile", out var moduleInterfaceSourceFile))
 			{
 				arguments.ModuleInterfaceSourceFile = new Path(moduleInterfaceSourceFile.AsString());

--- a/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/BuildTask.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/BuildTask.cs
@@ -85,7 +85,25 @@ namespace Soup.Build.Cpp
 
 			if (buildTable.TryGetValue("ModuleInterfacePartitionSourceFiles", out var moduleInterfacePartitionSourceFiles))
 			{
-				arguments.ModuleInterfacePartitionSourceFiles = moduleInterfacePartitionSourceFiles.AsList().Select(value => new Path(value.AsString())).ToList();
+				var paritionTargets = new List<PartitionSourceFile>();
+				foreach (var partition in moduleInterfacePartitionSourceFiles.AsList())
+				{
+					var partitionTable = partition.AsTable();
+
+					var partitionImports = new List<Path>();
+					if (partitionTable.TryGetValue("Imports", out var partitionImportsValue))
+					{
+						partitionImports = partitionImportsValue.AsList().Select(value => new Path(value.AsString())).ToList();
+					}
+
+					paritionTargets.Add(new PartitionSourceFile()
+					{
+						File = new Path(partitionTable["Source"].AsString()),
+						Imports = partitionImports,
+					});
+				}
+
+				arguments.ModuleInterfacePartitionSourceFiles = paritionTargets;
 			}
 
 			if (buildTable.TryGetValue("ModuleInterfaceSourceFile", out var moduleInterfaceSourceFile))

--- a/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/RecipeBuildTask.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/RecipeBuildTask.cs
@@ -155,11 +155,47 @@ namespace Soup.Build.Cpp
 			}
 
 			// Load the module interface partition files if present
-			var moduleInterfacePartitionSourceFiles = new List<string>();
+			var moduleInterfacePartitionSourceFiles = new List<IValue>();
 			if (recipeTable.TryGetValue("Partitions", out var partitionsValue))
 			{
-				moduleInterfacePartitionSourceFiles =
-					partitionsValue.AsList().Select(value => value.AsString()).ToList();
+				foreach (var partition in partitionsValue.AsList())
+				{
+					var targetPartitionTable = this.factory.CreateTable();
+					if (partition.IsString())
+					{
+						targetPartitionTable.Add(
+							"Source",
+							this.factory.Create(partition.AsString()));
+					}
+					else if (partition.IsTable())
+					{
+						var partitionTable = partition.AsTable();
+						if (partitionTable.TryGetValue("Source", out var partitionSourceValue))
+						{
+							targetPartitionTable.Add(
+								"Source",
+								this.factory.Create(partitionSourceValue.AsString()));
+						}
+						else
+						{
+							throw new InvalidOperationException("Partition table missing Source");
+						}
+
+						if (partitionTable.TryGetValue("Imports", out var partitionImportsValue))
+						{
+							var partitionImports = partitionImportsValue.AsList().Select(value => this.factory.Create(value.AsString()));
+							targetPartitionTable.Add(
+								"Imports",
+								this.factory.Create(this.factory.CreateList().Append(partitionImports)));
+						}
+					}
+					else
+					{
+						throw new InvalidOperationException("Unknown partition type.");
+					}
+
+					moduleInterfacePartitionSourceFiles.Add(this.factory.Create(targetPartitionTable));
+				}
 			}
 
 			// Load the module interface file if present
@@ -222,7 +258,7 @@ namespace Soup.Build.Cpp
 			buildTable["ObjectDirectory"] = this.factory.Create(objectDirectory.ToString());
 			buildTable["BinaryDirectory"] = this.factory.Create(binaryDirectory.ToString());
 			buildTable["ResourcesFile"] = this.factory.Create(resourcesFile);
-			buildTable.EnsureValueList(this.factory, "ModuleInterfacePartitionSourceFiles").Append(this.factory, moduleInterfacePartitionSourceFiles);
+			buildTable.EnsureValueList(this.factory, "ModuleInterfacePartitionSourceFiles").Append(moduleInterfacePartitionSourceFiles);
 			buildTable["ModuleInterfaceSourceFile"] = this.factory.Create(moduleInterfaceSourceFile);
 			buildTable["OptimizationLevel"] = this.factory.Create((long)optimizationLevel);
 			buildTable["GenerateSourceDebugInfo"] = this.factory.Create(generateSourceDebugInfo);

--- a/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/RecipeBuildTask.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/RecipeBuildTask.cs
@@ -154,6 +154,14 @@ namespace Soup.Build.Cpp
 				resourcesFile = resourcesFilePath.ToString();
 			}
 
+			// Load the module interface partition files if present
+			var moduleInterfacePartitionSourceFiles = new List<string>();
+			if (recipeTable.TryGetValue("Partitions", out var partitionsValue))
+			{
+				moduleInterfacePartitionSourceFiles =
+					partitionsValue.AsList().Select(value => value.AsString()).ToList();
+			}
+
 			// Load the module interface file if present
 			var moduleInterfaceSourceFile = string.Empty;
 			if (recipeTable.TryGetValue("Interface", out var interfaceValue))
@@ -214,6 +222,7 @@ namespace Soup.Build.Cpp
 			buildTable["ObjectDirectory"] = this.factory.Create(objectDirectory.ToString());
 			buildTable["BinaryDirectory"] = this.factory.Create(binaryDirectory.ToString());
 			buildTable["ResourcesFile"] = this.factory.Create(resourcesFile);
+			buildTable.EnsureValueList(this.factory, "ModuleInterfacePartitionSourceFiles").Append(this.factory, moduleInterfacePartitionSourceFiles);
 			buildTable["ModuleInterfaceSourceFile"] = this.factory.Create(moduleInterfaceSourceFile);
 			buildTable["OptimizationLevel"] = this.factory.Create((long)optimizationLevel);
 			buildTable["GenerateSourceDebugInfo"] = this.factory.Create(generateSourceDebugInfo);

--- a/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/ResolveToolsTask.cs
+++ b/Source/GenerateSharp/Extensions/Cpp/Extension/Tasks/ResolveToolsTask.cs
@@ -128,6 +128,7 @@ namespace Soup.Build.Cpp
 					visualCompilerVersionFolder + new Path("/include/"),
 					windows10KitVersionIncludePath + new Path("/ucrt/"),
 					windows10KitVersionIncludePath + new Path("/um/"),
+					windows10KitVersionIncludePath + new Path("/winrt/"),
 					windows10KitVersionIncludePath + new Path("/shared/"),
 				};
 			}


### PR DESCRIPTION
With this change I introduce the ability to define a set of C++ partition units and their dependency orders