### PR TITLE
Fix triangle builds

### DIFF
--- a/Source/Client/Core/Source/Build/RecipeBuildRunner.h
+++ b/Source/Client/Core/Source/Build/RecipeBuildRunner.h
@@ -278,7 +278,7 @@ namespace Soup::Core
 
 					// Keep track of the packages we have already built
 					auto insertBuildState = buildSet.emplace(
-						recipe.GetName(),
+						languagePackageName,
 						workingDirectory);
 
 					// Replace the find iterator so it can be used to update the shared table state

--- a/Source/Client/Core/UnitTests/Build/RecipeBuildRunnerTests.h
+++ b/Source/Client/Core/UnitTests/Build/RecipeBuildRunnerTests.h
@@ -184,8 +184,8 @@ namespace Soup::Core::UnitTests
 					{ "SDKs", Value(ValueList()), },
 					{ "SoupTargetDirectory", Value(std::string("C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/")), },
 					{ "TargetDirectory", Value(std::string("C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/")), },
-				})).ToString(),
-				ValueTableReader::Deserialize(myPackageGenerateParametersMockFile->Content).ToString(),
+				})),
+				ValueTableReader::Deserialize(myPackageGenerateParametersMockFile->Content),
 				"Verify file content match expected.");
 
 			auto myPackageGenerateReadAccessMockFile = fileSystem->GetMockFile(
@@ -652,7 +652,605 @@ namespace Soup::Core::UnitTests
 				myPackageGenerateGraph,
 				"Verify file content match expected.");
 		}
-		
+
+		// [[Fact]]
+		void Execute_TriangleDependency_NoRebuild()
+		{
+			// Register the test listener
+			auto testListener = std::make_shared<TestTraceListener>();
+			auto scopedTraceListener = ScopedTraceListenerRegister(testListener);
+
+			// Register the test file system
+			auto fileSystem = std::make_shared<MockFileSystem>();
+			auto scopedFileSystem = ScopedFileSystemRegister(fileSystem);
+
+			// Create the Recipe to build
+			fileSystem->CreateMockFile(
+				Path("C:/WorkingDirectory/MyPackage/Recipe.toml"),
+				std::make_shared<MockFile>(std::stringstream(R"(
+					Name = "MyPackage"
+					Language = "C++|1"
+					[Dependencies]
+					Runtime = [
+						"PackageA@1.2.3",
+						"PackageB@1.1.1",
+					]
+				)")));
+			fileSystem->CreateMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/Recipe.toml"),
+				std::make_shared<MockFile>(std::stringstream(R"(
+					Name = "PackageA"
+					Language = "C++|1"
+					[Dependencies]
+					Runtime = [
+						"PackageB@1.1.1",
+					]
+				)")));
+			fileSystem->CreateMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/Recipe.toml"),
+				std::make_shared<MockFile>(std::stringstream(R"(
+					Name = "PackageB"
+					Language = "C++|1"
+				)")));
+
+			auto myProjectOperationGraph = OperationGraph(
+				{},
+				std::vector<OperationId>({}),
+				std::vector<OperationInfo>({}));
+			auto myProjectOperationGraphContent = std::stringstream();
+			OperationGraphWriter::Serialize(myProjectOperationGraph, myProjectOperationGraphContent);
+			fileSystem->CreateMockFile(
+				Path("C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateEvaluateGraph.bog"),
+				std::make_shared<MockFile>(std::move(myProjectOperationGraphContent)));
+			auto packageAOperationGraph = OperationGraph(
+				{},
+				std::vector<OperationId>({}),
+				std::vector<OperationInfo>({}));
+			auto packageAOperationGraphContent = std::stringstream();
+			OperationGraphWriter::Serialize(packageAOperationGraph, packageAOperationGraphContent);
+			fileSystem->CreateMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateEvaluateGraph.bog"),
+				std::make_shared<MockFile>(std::move(packageAOperationGraphContent)));
+			auto packageBOperationGraph = OperationGraph(
+				{},
+				std::vector<OperationId>({}),
+				std::vector<OperationInfo>({}));
+			auto packageBOperationGraphContent = std::stringstream();
+			OperationGraphWriter::Serialize(packageBOperationGraph, packageBOperationGraphContent);
+			fileSystem->CreateMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateEvaluateGraph.bog"),
+				std::make_shared<MockFile>(std::move(packageBOperationGraphContent)));
+
+			// Register the test process manager
+			auto processManager = std::make_shared<MockProcessManager>();
+			auto scopedProcessManager = ScopedProcessManagerRegister(processManager);
+
+			// Register the test process manager
+			auto detourProcessManager = std::make_shared<Monitor::MockDetourProcessManager>();
+			auto scopedDetourProcessManager = Monitor::ScopedDetourProcessManagerRegister(detourProcessManager);
+
+			auto arguments = RecipeBuildArguments();
+			auto localUserConfig = LocalUserConfig();
+			auto uut = RecipeBuildRunner(arguments, localUserConfig);
+
+			auto workingDirectory = Path("C:/WorkingDirectory/MyPackage/");
+			uut.Execute(workingDirectory);
+
+			// Verify expected logs
+			Assert::AreEqual(
+				std::vector<std::string>({
+					"DIAG: 0>Load PackageLock: C:/WorkingDirectory/MyPackage/PackageLock.toml",
+					"INFO: 0>PackageLock file does not exist.",
+					"DIAG: 0>Load Recipe: C:/WorkingDirectory/MyPackage/Recipe.toml",
+					"DIAG: 0>Load Recipe: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/Recipe.toml",
+					"DIAG: 0>Load Recipe: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/Recipe.toml",
+					"DIAG: 1>Running Build: C++|PackageB",
+					"INFO: 1>Build 'PackageB'",
+					"INFO: 1>Check outdated parameters file: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt",     
+					"INFO: 1>Value Table file does not exist",
+					"INFO: 1>Save Parameters file",
+					"INFO: 1>Create Directory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 1>Check outdated read access file: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt",    
+					"INFO: 1>Path list file does not exist",
+					"INFO: 1>Save Read Access file",
+					"INFO: 1>Create Directory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 1>Check outdated write access file: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt",  
+					"INFO: 1>Path list file does not exist",
+					"INFO: 1>Save Write Access file",
+					"INFO: 1>Create Directory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"DIAG: 1>Loading previous operation graph",
+					"INFO: 1>Operation graph file does not exist",
+					"INFO: 1>No valid previous build graph found",
+					"DIAG: 1>Build evaluation start",
+					"DIAG: 1>Check for previous operation invocation",
+					"INFO: 1>Operation has no successful previous invocation",
+					"HIGH: 1>Generate Phase: C++|PackageB",
+					"DIAG: 1>Execute: [C:/Users/Me/.soup/packages/C++/PackageB/1.1.1] C:/testlocation/Generate/Soup.Build.Generate.exe C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"DIAG: 1>Allowed Read Access:",
+					"DIAG: 1>C:/testlocation/Generate/",
+					"DIAG: 1>C:/testlocation/Extensions/Soup.Cpp/0.2.2/",
+					"DIAG: 1>C:/Windows/",
+					"DIAG: 1>C:/Program Files/dotnet/",
+					"DIAG: 1>C:/Users/Me/.soup/packages/C++/PackageB/1.1.1",
+					"DIAG: 1>C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 1>Allowed Write Access:",
+					"DIAG: 1>C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 1>Build evaluation end",
+					"INFO: 1>Create Directory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 1>Loading generate evaluate operation graph",
+					"DIAG: 1>Loading previous operation graph",
+					"INFO: 1>Operation graph file does not exist",
+					"INFO: 1>No valid previous build graph found",
+					"INFO: 1>Create Directory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"DIAG: 1>Build evaluation start",
+					"DIAG: 1>Build evaluation end",
+					"INFO: 1>Saving updated build state",
+					"INFO: 1>Create Directory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 1>Done",
+					"DIAG: 2>Running Build: C++|PackageA",
+					"INFO: 2>Build 'PackageA'",
+					"INFO: 2>Check outdated parameters file: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt",     
+					"INFO: 2>Value Table file does not exist",
+					"INFO: 2>Save Parameters file",
+					"INFO: 2>Create Directory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 2>Check outdated read access file: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt",    
+					"INFO: 2>Path list file does not exist",
+					"INFO: 2>Save Read Access file",
+					"INFO: 2>Create Directory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 2>Check outdated write access file: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt",  
+					"INFO: 2>Path list file does not exist",
+					"INFO: 2>Save Write Access file",
+					"INFO: 2>Create Directory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"DIAG: 2>Loading previous operation graph",
+					"INFO: 2>Operation graph file does not exist",
+					"INFO: 2>No valid previous build graph found",
+					"DIAG: 2>Build evaluation start",
+					"DIAG: 2>Check for previous operation invocation",
+					"INFO: 2>Operation has no successful previous invocation",
+					"HIGH: 2>Generate Phase: C++|PackageA",
+					"DIAG: 2>Execute: [C:/Users/Me/.soup/packages/C++/PackageA/1.2.3] C:/testlocation/Generate/Soup.Build.Generate.exe C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"DIAG: 2>Allowed Read Access:",
+					"DIAG: 2>C:/testlocation/Generate/",
+					"DIAG: 2>C:/testlocation/Extensions/Soup.Cpp/0.2.2/",
+					"DIAG: 2>C:/Windows/",
+					"DIAG: 2>C:/Program Files/dotnet/",
+					"DIAG: 2>C:/Users/Me/.soup/packages/C++/PackageA/1.2.3",
+					"DIAG: 2>C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 2>C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 2>Allowed Write Access:",
+					"DIAG: 2>C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 2>Build evaluation end",
+					"INFO: 2>Create Directory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 2>Loading generate evaluate operation graph",
+					"DIAG: 2>Loading previous operation graph",
+					"INFO: 2>Operation graph file does not exist",
+					"INFO: 2>No valid previous build graph found",
+					"INFO: 2>Create Directory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"DIAG: 2>Build evaluation start",
+					"DIAG: 2>Build evaluation end",
+					"INFO: 2>Saving updated build state",
+					"INFO: 2>Create Directory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 2>Done",
+					"DIAG: 3>Running Build: C++|PackageB",
+					"DIAG: 3>Recipe already built: C++|PackageB",
+					"DIAG: 3>Running Build: C++|MyPackage",
+					"INFO: 3>Build 'MyPackage'",
+					"INFO: 3>Check outdated parameters file: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt",
+					"INFO: 3>Value Table file does not exist",
+					"INFO: 3>Save Parameters file",
+					"INFO: 3>Create Directory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 3>Check outdated read access file: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt",
+					"INFO: 3>Path list file does not exist",
+					"INFO: 3>Save Read Access file",
+					"INFO: 3>Create Directory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 3>Check outdated write access file: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt",
+					"INFO: 3>Path list file does not exist",
+					"INFO: 3>Save Write Access file",
+					"INFO: 3>Create Directory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"DIAG: 3>Loading previous operation graph",
+					"INFO: 3>Operation graph file does not exist",
+					"INFO: 3>No valid previous build graph found",
+					"DIAG: 3>Build evaluation start",
+					"DIAG: 3>Check for previous operation invocation",
+					"INFO: 3>Operation has no successful previous invocation",
+					"HIGH: 3>Generate Phase: C++|MyPackage",
+					"DIAG: 3>Execute: [C:/WorkingDirectory/MyPackage/] C:/testlocation/Generate/Soup.Build.Generate.exe C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"DIAG: 3>Allowed Read Access:",
+					"DIAG: 3>C:/testlocation/Generate/",
+					"DIAG: 3>C:/testlocation/Extensions/Soup.Cpp/0.2.2/",
+					"DIAG: 3>C:/Windows/",
+					"DIAG: 3>C:/Program Files/dotnet/",
+					"DIAG: 3>C:/WorkingDirectory/MyPackage/",
+					"DIAG: 3>C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 3>C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 3>C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 3>Allowed Write Access:",
+					"DIAG: 3>C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 3>Build evaluation end",
+					"INFO: 3>Create Directory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 3>Loading generate evaluate operation graph",
+					"DIAG: 3>Loading previous operation graph",
+					"INFO: 3>Operation graph file does not exist",
+					"INFO: 3>No valid previous build graph found",
+					"INFO: 3>Create Directory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"DIAG: 3>Build evaluation start",
+					"DIAG: 3>Build evaluation end",
+					"INFO: 3>Saving updated build state",
+					"INFO: 3>Create Directory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"INFO: 3>Done",
+				}),
+				testListener->GetMessages(),
+				"Verify log messages match expected.");
+
+			// Verify expected file system requests
+			Assert::AreEqual(
+				std::vector<std::string>({
+					"Exists: C:/WorkingDirectory/MyPackage/PackageLock.toml",
+					"Exists: C:/WorkingDirectory/MyPackage/Recipe.toml",
+					"OpenReadBinary: C:/WorkingDirectory/MyPackage/Recipe.toml",
+					"GetCurrentDirectory",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/Recipe.toml",
+					"OpenReadBinary: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/Recipe.toml",
+					"GetCurrentDirectory",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/Recipe.toml",
+					"OpenReadBinary: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/Recipe.toml",
+					"GetCurrentDirectory",
+					"GetCurrentDirectory",
+					"GetCurrentDirectory",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/RootRecipe.toml",
+					"Exists: C:/Users/Me/.soup/packages/C++/RootRecipe.toml",
+					"Exists: C:/Users/Me/.soup/packages/RootRecipe.toml",
+					"Exists: C:/Users/Me/.soup/RootRecipe.toml",
+					"Exists: C:/Users/Me/RootRecipe.toml",
+					"Exists: C:/Users/RootRecipe.toml",
+					"Exists: C:/RootRecipe.toml",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateGraph.bog",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateGraph.bog",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateEvaluateGraph.bog",
+					"OpenReadBinary: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateEvaluateGraph.bog",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/EvaluateResultGraph.bog",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/EvaluateResultGraph.bog",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/RootRecipe.toml",
+					"Exists: C:/Users/Me/.soup/packages/C++/RootRecipe.toml",
+					"Exists: C:/Users/Me/.soup/packages/RootRecipe.toml",
+					"Exists: C:/Users/Me/.soup/RootRecipe.toml",
+					"Exists: C:/Users/Me/RootRecipe.toml",
+					"Exists: C:/Users/RootRecipe.toml",
+					"Exists: C:/RootRecipe.toml",
+					"GetCurrentDirectory",
+					"GetCurrentDirectory",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateGraph.bog",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateGraph.bog",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateEvaluateGraph.bog",
+					"OpenReadBinary: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateEvaluateGraph.bog",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/EvaluateResultGraph.bog",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"Exists: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/EvaluateResultGraph.bog",
+					"GetCurrentDirectory",
+					"Exists: C:/WorkingDirectory/RootRecipe.toml",
+					"Exists: C:/RootRecipe.toml",
+					"GetCurrentDirectory",
+					"GetCurrentDirectory",
+					"GetCurrentDirectory",
+					"GetCurrentDirectory",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateGraph.bog",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateGraph.bog",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateEvaluateGraph.bog",
+					"OpenReadBinary: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateEvaluateGraph.bog",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/EvaluateResultGraph.bog",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"CreateDirectory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"Exists: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"CreateDirectory: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"OpenWriteBinary: C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/EvaluateResultGraph.bog",
+				}),
+				fileSystem->GetRequests(),
+				"Verify file system requests match expected.");
+
+			// Verify expected process requests
+			Assert::AreEqual(
+				std::vector<std::string>({
+					"GetCurrentProcessFileName",
+					"GetCurrentProcessFileName",
+					"GetCurrentProcessFileName",
+					"GetCurrentProcessFileName",
+					"GetCurrentProcessFileName",
+					"GetCurrentProcessFileName",
+				}),
+				processManager->GetRequests(),
+				"Verify process manager requests match expected.");
+
+			Assert::AreEqual(
+				std::vector<std::string>({
+					"CreateDetourProcess: 1 [C:/Users/Me/.soup/packages/C++/PackageB/1.1.1] C:/testlocation/Generate/Soup.Build.Generate.exe C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/ Environment [2] 1 AllowedRead [6] AllowedWrite [1]",
+					"ProcessStart: 1",
+					"WaitForExit: 1",
+					"GetStandardOutput: 1",
+					"GetStandardError: 1",
+					"GetExitCode: 1",
+					"CreateDetourProcess: 2 [C:/Users/Me/.soup/packages/C++/PackageA/1.2.3] C:/testlocation/Generate/Soup.Build.Generate.exe C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/ Environment [2] 1 AllowedRead [7] AllowedWrite [1]",
+					"ProcessStart: 2",
+					"WaitForExit: 2",
+					"GetStandardOutput: 2",
+					"GetStandardError: 2",
+					"GetExitCode: 2",
+					"CreateDetourProcess: 3 [C:/WorkingDirectory/MyPackage/] C:/testlocation/Generate/Soup.Build.Generate.exe C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/ Environment [2] 1 AllowedRead [8] AllowedWrite [1]",
+					"ProcessStart: 3",
+					"WaitForExit: 3",
+					"GetStandardOutput: 3",
+					"GetStandardError: 3",
+					"GetExitCode: 3",
+				}),
+				detourProcessManager->GetRequests(),
+				"Verify detour process manager requests match expected.");
+
+			// Verify files
+			auto packageAGenerateParametersMockFile = fileSystem->GetMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt"));
+			Assert::AreEqual(
+				ValueTable(std::map<std::string, Value>({
+					{ "Dependencies", Value(ValueTable(std::map<std::string, Value>({
+						{ "Runtime", Value(ValueTable(std::map<std::string, Value>({
+							{ "PackageB", Value(ValueTable(std::map<std::string, Value>({
+								{ "Reference", Value(std::string("PackageB@1.1.1")), },
+								{ "SoupTargetDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/")), },
+								{ "TargetDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/")), },
+							}))), },
+						}))), },
+					}))), },
+					{ "LanguageExtensionPath", Value(std::string("C:/testlocation/Extensions/Soup.Cpp/0.2.2/Soup.Cpp.dll")), },
+					{ "PackageDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3")), },
+					{ "SDKs", Value(ValueList()), },
+					{ "SoupTargetDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/")), },
+					{ "TargetDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/")), },
+				})),
+				ValueTableReader::Deserialize(packageAGenerateParametersMockFile->Content),
+				"Verify file content match expected.");
+
+			auto packageAGenerateReadAccessMockFile = fileSystem->GetMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt"));
+			Assert::AreEqual(
+				"C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/\nC:/Users/Me/.soup/packages/C++/PackageA/1.2.3\nC:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/\n",
+				packageAGenerateReadAccessMockFile->Content.str(),
+				"Verify file content match expected.");
+
+			auto packageAGenerateWriteAccessMockFile = fileSystem->GetMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt"));
+			Assert::AreEqual(
+				"C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/\n",
+				packageAGenerateWriteAccessMockFile->Content.str(),
+				"Verify file content match expected.");
+
+			auto packageAGenerateGraphMockFile = fileSystem->GetMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateGraph.bog"));
+			auto packageAGenerateGraph = OperationGraphReader::Deserialize(packageAGenerateGraphMockFile->Content);
+
+			// TODO: Clear time for now until mocked
+			for (auto& operation : packageAGenerateGraph.GetOperations())
+				operation.second.EvaluateTime = std::chrono::time_point<std::chrono::system_clock>::min();
+
+			Assert::AreEqual(
+				OperationGraph(
+					{
+					},
+					std::vector<OperationId>({
+						1,
+					}),
+					std::vector<OperationInfo>({
+						OperationInfo(
+							1,
+							"Generate Phase: C++|PackageA",
+							CommandInfo(
+								Path("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3"),
+								Path("C:/testlocation/Generate/Soup.Build.Generate.exe"),
+								"C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"),
+							{},
+							{},
+							{},
+							{},
+							{},
+							1,
+							true,
+							std::chrono::time_point<std::chrono::system_clock>::min(),
+							{},
+							{}),
+					})),
+				packageAGenerateGraph,
+				"Verify file content match expected.");
+
+			auto packageBGenerateParametersMockFile = fileSystem->GetMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt"));
+			Assert::AreEqual(
+				ValueTable(std::map<std::string, Value>({
+					{ "Dependencies", Value(ValueTable()), },
+					{ "LanguageExtensionPath", Value(std::string("C:/testlocation/Extensions/Soup.Cpp/0.2.2/Soup.Cpp.dll")), },
+					{ "PackageDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1")), },
+					{ "SDKs", Value(ValueList()), },
+					{ "SoupTargetDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/")), },
+					{ "TargetDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/")), },
+				})),
+				ValueTableReader::Deserialize(packageBGenerateParametersMockFile->Content),
+				"Verify file content match expected.");
+
+			auto packageBGenerateReadAccessMockFile = fileSystem->GetMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt"));
+			Assert::AreEqual(
+				"C:/Users/Me/.soup/packages/C++/PackageB/1.1.1\nC:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/\n",
+				packageBGenerateReadAccessMockFile->Content.str(),
+				"Verify file content match expected.");
+
+			auto packageBGenerateWriteAccessMockFile = fileSystem->GetMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt"));
+			Assert::AreEqual(
+				"C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/\n",
+				packageBGenerateWriteAccessMockFile->Content.str(),
+				"Verify file content match expected.");
+
+			auto packageBGenerateGraphMockFile = fileSystem->GetMockFile(
+				Path("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateGraph.bog"));
+			auto packageBGenerateGraph = OperationGraphReader::Deserialize(packageBGenerateGraphMockFile->Content);
+
+			// TODO: Clear time for now until mocked
+			for (auto& operation : packageBGenerateGraph.GetOperations())
+				operation.second.EvaluateTime = std::chrono::time_point<std::chrono::system_clock>::min();
+
+			Assert::AreEqual(
+				OperationGraph(
+					{
+					},
+					std::vector<OperationId>({
+						1,
+					}),
+					std::vector<OperationInfo>({
+						OperationInfo(
+							1,
+							"Generate Phase: C++|PackageB",
+							CommandInfo(
+								Path("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1"),
+								Path("C:/testlocation/Generate/Soup.Build.Generate.exe"),
+								"C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"),
+							{},
+							{},
+							{},
+							{},
+							{},
+							1,
+							true,
+							std::chrono::time_point<std::chrono::system_clock>::min(),
+							{},
+							{}),
+					})),
+				packageBGenerateGraph,
+				"Verify file content match expected.");
+
+			auto myPackageGenerateParametersMockFile = fileSystem->GetMockFile(
+				Path("C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateParameters.bvt"));
+			Assert::AreEqual(
+				ValueTable(std::map<std::string, Value>({
+					{ "Dependencies", Value(ValueTable(std::map<std::string, Value>({
+						{ "Runtime", Value(ValueTable(std::map<std::string, Value>({
+							{ "PackageA", Value(ValueTable(std::map<std::string, Value>({
+								{ "Reference", Value(std::string("PackageA@1.2.3")), },
+								{ "SoupTargetDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/")), },
+								{ "TargetDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/")), },
+							}))), },
+							{ "PackageB", Value(ValueTable(std::map<std::string, Value>({
+								{ "Reference", Value(std::string("PackageB@1.1.1")), },
+								{ "SoupTargetDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/")), },
+								{ "TargetDirectory", Value(std::string("C:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/")), },
+							}))), },
+						}))), },
+					}))), },
+					{ "LanguageExtensionPath", Value(std::string("C:/testlocation/Extensions/Soup.Cpp/0.2.2/Soup.Cpp.dll")), },
+					{ "PackageDirectory", Value(std::string("C:/WorkingDirectory/MyPackage/")), },
+					{ "SDKs", Value(ValueList()), },
+					{ "SoupTargetDirectory", Value(std::string("C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/")), },
+					{ "TargetDirectory", Value(std::string("C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/")), },
+				})),
+				ValueTableReader::Deserialize(myPackageGenerateParametersMockFile->Content),
+				"Verify file content match expected.");
+
+			auto myPackageGenerateReadAccessMockFile = fileSystem->GetMockFile(
+				Path("C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateReadAccess.txt"));
+			Assert::AreEqual(
+				"C:/Users/Me/.soup/packages/C++/PackageA/1.2.3/out/J_HqSstV55vlb-x6RWC_hLRFRDU/\nC:/Users/Me/.soup/packages/C++/PackageB/1.1.1/out/J_HqSstV55vlb-x6RWC_hLRFRDU/\nC:/WorkingDirectory/MyPackage/\nC:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/\n",
+				myPackageGenerateReadAccessMockFile->Content.str(),
+				"Verify file content match expected.");
+
+			auto myPackageGenerateWriteAccessMockFile = fileSystem->GetMockFile(
+				Path("C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateWriteAccess.txt"));
+			Assert::AreEqual(
+				"C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/\n",
+				myPackageGenerateWriteAccessMockFile->Content.str(),
+				"Verify file content match expected.");
+
+			auto myPackageGenerateGraphMockFile = fileSystem->GetMockFile(
+				Path("C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateGraph.bog"));
+			auto myPackageGenerateGraph = OperationGraphReader::Deserialize(myPackageGenerateGraphMockFile->Content);
+
+			// TODO: Clear time for now until mocked
+			for (auto& operation : myPackageGenerateGraph.GetOperations())
+				operation.second.EvaluateTime = std::chrono::time_point<std::chrono::system_clock>::min();
+
+			Assert::AreEqual(
+				OperationGraph(
+					{
+					},
+					std::vector<OperationId>({
+						1,
+					}),
+					std::vector<OperationInfo>({
+						OperationInfo(
+							1,
+							"Generate Phase: C++|MyPackage",
+							CommandInfo(
+								Path("C:/WorkingDirectory/MyPackage/"),
+								Path("C:/testlocation/Generate/Soup.Build.Generate.exe"),
+								"C:/WorkingDirectory/MyPackage/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"),
+							{},
+							{},
+							{},
+							{},
+							{},
+							1,
+							true,
+							std::chrono::time_point<std::chrono::system_clock>::min(),
+							{},
+							{}),
+					})),
+				myPackageGenerateGraph,
+				"Verify file content match expected.");
+		}
+
 		// [[Fact]]
 		void Execute_PackageLock_OverrideBuildDependency()
 		{
@@ -1090,5 +1688,7 @@ namespace Soup::Core::UnitTests
 				myPackageGenerateGraph,
 				"Verify file content match expected.");
 		}
+
+		
 	};
 }

--- a/Source/Client/Core/UnitTests/gen/Build/RecipeBuildRunnerTests.gen.h
+++ b/Source/Client/Core/UnitTests/gen/Build/RecipeBuildRunnerTests.gen.h
@@ -8,6 +8,7 @@ TestState RunRecipeBuildRunnerTests()
 	TestState state = { 0, 0 };
 	state += Soup::Test::RunTest(className, "Initialize_Success", [&testClass]() { testClass->Initialize_Success(); });
 	state += Soup::Test::RunTest(className, "Execute_NoDependencies", [&testClass]() { testClass->Execute_NoDependencies(); });
+	state += Soup::Test::RunTest(className, "Execute_TriangleDependency_NoRebuild", [&testClass]() { testClass->Execute_TriangleDependency_NoRebuild(); });
 	state += Soup::Test::RunTest(className, "Execute_BuildDependency", [&testClass]() { testClass->Execute_BuildDependency(); });
 	state += Soup::Test::RunTest(className, "Execute_PackageLock_OverrideBuildDependency", [&testClass]() { testClass->Execute_PackageLock_OverrideBuildDependency(); });
 


### PR DESCRIPTION
The runtime check for builds that have already been processed had a bug where the language name was not being used in the map.