### PR TITLE
Move soup out directory create check to runtime

### DIFF
--- a/Source/Client/Core/Source/Build/BuildRunner.h
+++ b/Source/Client/Core/Source/Build/BuildRunner.h
@@ -260,6 +260,13 @@ namespace Soup::Core
 			/////////////////////////////////////////////
 			if (!_arguments.SkipGenerate)
 			{
+				// Ensure the target directories exists
+				if (!System::IFileSystem::Current().Exists(soupTargetDirectory))
+				{
+					Log::Info("Create Directory: " + soupTargetDirectory.ToString());
+					System::IFileSystem::Current().CreateDirectory2(soupTargetDirectory);
+				}
+
 				auto ranGenerate = RunIncrementalGenerate(
 					packageInfo,
 					macroPackageDirectory,

--- a/Source/Client/Core/Source/ValueTable/ValueTableManager.h
+++ b/Source/Client/Core/Source/ValueTable/ValueTableManager.h
@@ -62,13 +62,6 @@ namespace Soup::Core
 		{
 			auto targetFolder = valueTableFile.GetParent();
 
-			// Ensure the target directories exists
-			if (!System::IFileSystem::Current().Exists(targetFolder))
-			{
-				Log::Info("Create Directory: " + targetFolder.ToString());
-				System::IFileSystem::Current().CreateDirectory2(targetFolder);
-			}
-
 			// Open the file to write to
 			auto file = System::IFileSystem::Current().OpenWrite(valueTableFile, true);
 


### PR DESCRIPTION
Having the generate phase check the output directory exists was causing it to be included as input so moving it up one level.