### PR TITLE
Short Names + Path Set

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       if: matrix.os == 'ubuntu-24.04'
       run: soup build ./soup/code/client/cli/ -flavor ${{matrix.config}}
     - name: Soup Run Version
-      run: soup run ./soup/code/client/cli/ -flavor ${{matrix.config}} -args version
+      run: soup run ./soup/code/client/cli/ -flavor ${{matrix.config}} -- version
     - name: Soup Restore GenerateTest
       run: soup restore ./soup/code/generate-test/
     - name: Soup Build GenerateTest

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,7 @@
       "program": "${workspaceFolder}/out/run/Soup/soup-generate.exe",
       "args": [
         "false",
-        "${workspaceFolder}/out/cpp/local/samples-cpp-module-interface/1.0.0/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+        "${workspaceFolder}/out/cpp/local/samples-cpp-module-interface/1.0.0/J_HqSstV55vl/.soup/"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",
@@ -90,7 +90,7 @@
       "program": "${workspaceFolder}/out/run/lib/soup/generate",
       "args": [
         "true",
-        "${workspaceFolder}/out/cpp/local/samples-console-application/1.0.0/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+        "${workspaceFolder}/out/cpp/local/samples-console-application/1.0.0/J_HqSstV55vl/.soup/"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",
@@ -148,7 +148,7 @@
       "name": "Debug Soup Core Test (VS)",
       "type": "cppvsdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/out/cpp/local/soup-core/0.1.1/J_HqSstV55vlb-x6RWC_hLRFRDU/bin/tests/TestHarness.exe",
+      "program": "${workspaceFolder}/out/cpp/local/soup-core/0.1.1/J_HqSstV55vl/bin/tests/TestHarness.exe",
       "args": [],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",
@@ -159,7 +159,7 @@
       "name": "Debug Soup Core Test (GDB)",
       "type": "cppdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/out/cpp/local/soup-core/0.1.1/J_HqSstV55vlb-x6RWC_hLRFRDU/bin/tests/TestHarness.exe",
+      "program": "${workspaceFolder}/out/cpp/local/soup-core/0.1.1/J_HqSstV55vl/bin/tests/TestHarness.exe",
       "args": [],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",

--- a/code/bench-tests/main.cpp
+++ b/code/bench-tests/main.cpp
@@ -232,19 +232,19 @@ int main() {
 		fileSystem->CreateMockDirectory(
 			Path(
 				"C:/WorkingDirectory/my-package/out/"
-				"J_HqSstV55vlb-x6RWC_hLRFRDU/"),
+				"J_HqSstV55vl/"),
 			std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 		fileSystem->CreateMockDirectory(
 			Path(
 				"C:/WorkingDirectory/my-package/out/"
-				"J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"),
+				"J_HqSstV55vl/.soup/"),
 			std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 		fileSystem->CreateMockDirectory(
 			Path(
 				"C:/WorkingDirectory/my-package/out/"
-				"J_HqSstV55vlb-x6RWC_hLRFRDU/temp/"),
+				"J_HqSstV55vl/temp/"),
 			std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 		fileSystem->CreateMockDirectory(
@@ -352,7 +352,7 @@ int main() {
 		fileSystem->CreateMockFile(
 			Path(
 				"C:/WorkingDirectory/my-package/out/"
-				"J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/Evaluate.bog"),
+				"J_HqSstV55vl/.soup/Evaluate.bog"),
 			std::make_shared<MockFile>(std::move(myPackageOperationGraphContent)));
 
 		auto soupCppOperationGraph =
@@ -495,7 +495,7 @@ int main() {
 						 {"/(TARGET_my-package)/",
 						  std::string(
 							  "C:/WorkingDirectory/my-package/out/"
-							  "J_HqSstV55vlb-x6RWC_hLRFRDU/")},
+							  "J_HqSstV55vl/")},
 					 })},
 				{"EvaluateReadAccess",
 				 ValueList(
@@ -566,7 +566,7 @@ int main() {
 		fileSystem->CreateMockFile(
 			Path(
 				"C:/WorkingDirectory/my-package/out/"
-				"J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/GenerateInput.bvt"),
+				"J_HqSstV55vl/.soup/GenerateInput.bvt"),
 			std::make_shared<MockFile>(std::move(myPackageGenerateInputContent)));
 
 		auto myPackageGenerateResults = OperationResults(
@@ -589,7 +589,7 @@ int main() {
 		fileSystem->CreateMockFile(
 			Path(
 				"C:/WorkingDirectory/my-package/out/"
-				"J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/Generate.bor"),
+				"J_HqSstV55vl/.soup/Generate.bor"),
 			std::make_shared<MockFile>(std::move(myPackageGenerateResultsContent)));
 
 		auto soupCppGenerateResults = OperationResults(
@@ -640,7 +640,7 @@ int main() {
 		fileSystem->CreateMockFile(
 			Path(
 				"C:/WorkingDirectory/my-package/out/"
-				"J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/Evaluate.bor"),
+				"J_HqSstV55vl/.soup/Evaluate.bor"),
 			std::make_shared<MockFile>(std::move(myPackageEvaluateResultsContent)));
 
 		// Register the test process manager

--- a/code/bench-tests/package-lock.sml
+++ b/code/bench-tests/package-lock.sml
@@ -9,7 +9,7 @@ Closure: {
 		'monitor-shared': { Version: '../monitor/shared/', Build: '0', Tool: '0' }
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../sml/', Build: '0', Tool: '0' }

--- a/code/bench-tests/package-lock.sml
+++ b/code/bench-tests/package-lock.sml
@@ -9,7 +9,7 @@ Closure: {
 		'monitor-shared': { Version: '../monitor/shared/', Build: '0', Tool: '0' }
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.8, Digest: 'sha256:a43a45de9efabdc5b6d204302d4309d00ab3c21d3cce0cfc2f136b1c652376b1', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../sml/', Build: '0', Tool: '0' }

--- a/code/bench-tests/package-lock.sml
+++ b/code/bench-tests/package-lock.sml
@@ -7,7 +7,7 @@ Closure: {
 	'C++': {
 		'monitor-host': { Version: '../monitor/host/', Build: '0', Tool: '0' }
 		'monitor-shared': { Version: '../monitor/shared/', Build: '0', Tool: '0' }
-		'mwasplund|cryptopp': { Version: 1.2.9, Digest: 'sha256:53e593acbdfcaa81f285bcb64dabc3d38f36fd9bff7168d3c10a5d9ef752f446', Build: '0', Tool: '0' }
+		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }

--- a/code/client/cli/package-lock.sml
+++ b/code/client/cli/package-lock.sml
@@ -10,7 +10,7 @@ Closure: {
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|ftxui': { Version: 6.1.10, Digest: 'sha256:e3479e781f31bcd64231becc3ff3e33acd7edad78ea7807dfdff296448b75348', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../../sml/', Build: '0', Tool: '0' }
@@ -24,24 +24,16 @@ Builds: {
 	'0': {
 		Wren: {
 			'soup|cpp': {
-				Version: 0.20.1
-				Digest: 'sha256:03c5b657804b220628f08a2411130e32289ada0375c475928e64ca5d89a0905a'
-				Artifacts: {
-					Linux: 'sha256:4737f68f448976de1501556f7e95a2c92c1c6f1ab067c8d369e71d8c96a6cb2e'
-					Windows: 'sha256:44ee8107fc669e21753e508caa4c62faae8f5cd46d8126dd4559446b7f7d1e23'
-				}
+				Version: 0.20.3
+				Digest: 'sha256:01090a3637e82e3a428175f4a5c562cbbd87488b4ac26a7bd0b5b9f3706ebd57'
 			}
 		}
 	}
 	'1': {
 		Wren: {
 			'soup|cpp': {
-				Version: 0.20.1
-				Digest: 'sha256:03c5b657804b220628f08a2411130e32289ada0375c475928e64ca5d89a0905a'
-				Artifacts: {
-					Linux: 'sha256:4737f68f448976de1501556f7e95a2c92c1c6f1ab067c8d369e71d8c96a6cb2e'
-					Windows: 'sha256:44ee8107fc669e21753e508caa4c62faae8f5cd46d8126dd4559446b7f7d1e23'
-				}
+				Version: 0.20.3
+				Digest: 'sha256:01090a3637e82e3a428175f4a5c562cbbd87488b4ac26a7bd0b5b9f3706ebd57'
 			}
 			'mwasplund|soup-test-cpp': {
 				Version: 0.19.0

--- a/code/client/cli/package-lock.sml
+++ b/code/client/cli/package-lock.sml
@@ -10,7 +10,7 @@ Closure: {
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|ftxui': { Version: 6.1.10, Digest: 'sha256:e3479e781f31bcd64231becc3ff3e33acd7edad78ea7807dfdff296448b75348', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.8, Digest: 'sha256:a43a45de9efabdc5b6d204302d4309d00ab3c21d3cce0cfc2f136b1c652376b1', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../../sml/', Build: '0', Tool: '0' }

--- a/code/client/cli/package-lock.sml
+++ b/code/client/cli/package-lock.sml
@@ -7,7 +7,7 @@ Closure: {
 	'C++': {
 		'monitor-host': { Version: '../../monitor/host/', Build: '0', Tool: '0' }
 		'monitor-shared': { Version: '../../monitor/shared/', Build: '0', Tool: '0' }
-		'mwasplund|cryptopp': { Version: 1.2.9, Digest: 'sha256:53e593acbdfcaa81f285bcb64dabc3d38f36fd9bff7168d3c10a5d9ef752f446', Build: '0', Tool: '0' }
+		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|ftxui': { Version: 6.1.10, Digest: 'sha256:e3479e781f31bcd64231becc3ff3e33acd7edad78ea7807dfdff296448b75348', Build: '0', Tool: '0' }
 		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }

--- a/code/client/cli/recipe.sml
+++ b/code/client/cli/recipe.sml
@@ -1,5 +1,5 @@
 Name: 'soup'
-Version: 0.48.0
+Version: 0.48.1
 Language: 'C++|0'
 Type: 'Executable'
 Source: [

--- a/code/client/cli/source/commands/version-command.h
+++ b/code/client/cli/source/commands/version-command.h
@@ -29,7 +29,7 @@ namespace Soup::Client {
 			// TODO var version =
 			// Assembly.GetExecutingAssembly().GetName().Version;
 			// Log::Message($"{version.Major}.{version.Minor}.{version.Build}");
-			Log::HighPriority("0.48.0");
+			Log::HighPriority("0.48.1");
 		}
 
 	private:

--- a/code/client/core/source/build/build-runner.cpp
+++ b/code/client/core/source/build/build-runner.cpp
@@ -380,7 +380,7 @@ namespace Soup::Core::Build {
 				auto updatedGeneratePhase1Result = GenerateResult();
 				if (!GenerateResultManager::TryLoadState(
 						generatePhase1ResultFile, updatedGeneratePhase1Result, _fileSystemState)) {
-					throw std::runtime_error("Missing required generate phase 1 result.");
+					throw std::runtime_error(std::format("Missing required generate phase 1 result: {}", generatePhase1ResultFile.ToString()));
 				}
 
 				Log::Diag("Map previous operation graph observed results");

--- a/code/client/core/source/build/recipe-build-location-manager.cpp
+++ b/code/client/core/source/build/recipe-build-location-manager.cpp
@@ -111,8 +111,12 @@ namespace Soup::Core {
 			// Add unique folder name for parameters
 			auto parametersStream = std::stringstream();
 			ValueTableWriter::Serialize(globalParameters, parametersStream);
-			auto hashParameters = CryptoPP::Sha1::HashBase64(parametersStream.str());
-			auto uniqueParametersFolder = Path(std::format("./{}/", hashParameters));
+			auto hashParameters = CryptoPP::Sha1::HashBase64Url(parametersStream.str());
+
+			// Shorten the hash to keep it under control with a small risk of collisions
+			auto uniqueName = hashParameters.substr(0, 12);
+
+			auto uniqueParametersFolder = Path(std::format("./{}/", uniqueName));
 			rootOutput = rootOutput + uniqueParametersFolder;
 
 			return rootOutput;

--- a/code/client/core/tests/build/build-load-engine-tests.cpp
+++ b/code/client/core/tests/build/build-load-engine-tests.cpp
@@ -341,7 +341,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -532,7 +532,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -927,7 +927,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -939,7 +939,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {3,
 								  "C:/Users/Me/.soup/packages/C++/user1/test-tool/3.3.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 							{4,
 							 {
@@ -951,7 +951,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {2,
 								  "C:/Users/Me/.soup/packages/Wren/user1/cpp/4.5.6/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 						})),
 				packageProvider,
@@ -1258,7 +1258,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -1270,7 +1270,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {2,
 								  "C:/Users/Me/.soup/packages/Wren/user1/test-build/3.3.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 							{4,
 							 {
@@ -1690,7 +1690,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -1702,7 +1702,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {3,
 								  "C:/Users/Me/.soup/packages/C++/user1/test-tool/3.3.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 							{4,
 							 {
@@ -1714,7 +1714,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {2,
 								  "C:/Users/Me/.soup/packages/Wren/user1/test-build/3.3.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 						})),
 				packageProvider,
@@ -2005,7 +2005,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -2017,7 +2017,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {2,
 								  "C:/WorkingDirectory/test-build/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 							{4,
 							 {
@@ -2514,7 +2514,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -2526,10 +2526,10 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {2,
 								  "C:/Users/Me/.soup/packages/Wren/user1/test-build/3.3.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 								 {3,
 								  "C:/Users/Me/.soup/packages/Wren/user1/test-build2/3.3.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 							{4,
 							 {
@@ -2942,7 +2942,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -2954,13 +2954,13 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {3,
 								  "C:/Users/Me/.soup/packages/Wren/user1/test-build2/4.4.4/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 							{4,
 							 {
 								 {2,
 								  "C:/Users/Me/.soup/packages/Wren/user1/test-build/3.3.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 							{5,
 							 {
@@ -3380,7 +3380,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -3392,7 +3392,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {3,
 								  "C:/Users/Me/.soup/packages/C++/user1/test-tool/3.3.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 							{4,
 							 {
@@ -3404,7 +3404,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {2,
 								  "C:/Users/Me/.soup/packages/Wren/user1/test-build/3.3.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 						})),
 				packageProvider,
@@ -3841,7 +3841,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -3853,19 +3853,19 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {3,
 								  "C:/Users/Me/.soup/packages/Wren/user1/wren/2.2.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 							{4,
 							 {
 								 {2,
 								  "C:/Users/Me/.soup/packages/Wren/user1/test-build/3.3.4/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 							{5,
 							 {
 								 {5,
 								  "C:/Users/Me/.soup/packages/Wren/user1/cpp/1.1.2/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 						})),
 				packageProvider,
@@ -4180,9 +4180,9 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 								 {2,
-								  "C:/WorkingDirectory/package1/out/zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "C:/WorkingDirectory/package1/out/zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -4194,7 +4194,7 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {3,
 								  "C:/Users/Me/.soup/packages/Wren/user1/csharp/2.2.3/out/"
-								  "zDqRc65c9x3jySpevCCCyZ15fGs/"},
+								  "zDqRc65c9x3j/"},
 							 }},
 						})),
 				packageProvider,
@@ -4513,13 +4513,13 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 								 {2,
 								  "C:/Users/Me/.soup/packages/C++/user1/package-a/3.3.3/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 								 {3,
 								  "C:/Users/Me/.soup/packages/C++/user1/package-b/4.4.4/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {
@@ -4817,10 +4817,10 @@ namespace Soup::Core::Build::UnitTests {
 							 {
 								 {1,
 								  "C:/WorkingDirectory/my-package/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 								 {2,
 								  "C:/Users/Me/.soup/packages/C#/user1/package1/4.4.4/out/"
-								  "zxAcy-Et010fdZUKLgFemwwWuC8/"},
+								  "zxAcy-Et010f/"},
 							 }},
 							{2,
 							 {

--- a/code/client/core/tests/build/build-tests.cpp
+++ b/code/client/core/tests/build/build-tests.cpp
@@ -154,7 +154,7 @@ namespace Soup::Core::UnitTests {
 			monitorProcessManager->RegisterExecuteCallback(
 				std::format(
 					"CreateMonitorProcess: 2 [C:/WorkingDirectory/my-package/] {0} true "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/ "
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/ "
 					"Environment [2] 1 0 AllowedRead [7] AllowedWrite [1]",
 					GetGenerateExePath()),
 				[&](Monitor::ISystemAccessMonitor & /*monitor*/) {
@@ -170,7 +170,7 @@ namespace Soup::Core::UnitTests {
 						myPackageGenerateResultContent);
 					fileSystem->CreateMockFile(
 						Path(
-							"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+							"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 							"generate-phase1.bgr"),
 						std::make_shared<MockFile>(std::move(myPackageGenerateResultContent)));
 				});
@@ -180,7 +180,7 @@ namespace Soup::Core::UnitTests {
 					"CreateMonitorProcess: 1 [C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/] {0} "
 					"true "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/ Environment [2] 1 0 AllowedRead [7] "
+					"WhSd9nSIoVKW/.soup/ Environment [2] 1 0 AllowedRead [7] "
 					"AllowedWrite [1]",
 					GetGenerateExePath()),
 				[&](Monitor::ISystemAccessMonitor & /*monitor*/) {
@@ -197,7 +197,7 @@ namespace Soup::Core::UnitTests {
 					fileSystem->CreateMockFile(
 						Path(
 							"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-							"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr"),
+							"WhSd9nSIoVKW/.soup/generate-phase1.bgr"),
 						std::make_shared<MockFile>(std::move(soupCppGenerateResultContent)));
 				});
 
@@ -244,25 +244,25 @@ namespace Soup::Core::UnitTests {
 					"INFO: 2>Build 'soup|cpp'",
 					"INFO: 2>Preload Directory Missing: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"INFO: 2>Checking for existing Generate Phase 1 Result",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"INFO: 2>Generate result file does not exist",
 					"INFO: 2>Phase1 no previous graph",
 					"INFO: 2>Create Directory: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/",
+					"WhSd9nSIoVKW/.soup/",
 					"INFO: 2>Check outdated generate input file: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt",
+					"WhSd9nSIoVKW/.soup/generate-input.bvt",
 					"INFO: 2>Value Table file does not exist",
 					"INFO: 2>Save Generate Input file",
 					"INFO: 2>Checking for existing Generate Operation Results",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor",
 					"INFO: 2>Operation results file does not exist",
 					"INFO: 2>No previous results found",
 					"DIAG: 2>Build evaluation start 1",
@@ -274,7 +274,7 @@ namespace Soup::Core::UnitTests {
 						"DIAG: 2>Execute: [C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/] {0} "
 						"true "
 						"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-						"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/",
+						"WhSd9nSIoVKW/.soup/",
 						GetGenerateExePath()),
 					"DIAG: 2>Allowed Read Access:",
 					std::format("DIAG: 2>{0}", GetRuntimeLibraryPath()),
@@ -285,44 +285,44 @@ namespace Soup::Core::UnitTests {
 					"DIAG: 2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"DIAG: 2>Allowed Write Access:",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"DIAG: 2>Worker thread end 1",
 					"DIAG: 2>Build evaluation end",
 					"INFO: 2>Save operation results",
 					"INFO: 2>Loading updated Generate Phase 1 Result",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"DIAG: 2>Map previous operation graph observed results",
 					"INFO: 2>Create Directory: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/temp/",
+					"WhSd9nSIoVKW/temp/",
 					"DIAG: 2>Build evaluation skipped",
 					"INFO: 2>Nothing to do.",
 					"DIAG: 1>Running Build: [C++]my-package",
 					"INFO: 1>Build 'my-package'",
 					"INFO: 1>Preload Directory Missing: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"INFO: 1>Checking for existing Generate Phase 1 Result",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
 					"INFO: 1>Generate result file does not exist",
 					"INFO: 1>Phase1 no previous graph",
 					"INFO: 1>Create Directory: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 					"INFO: 1>Check outdated generate input file: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"INFO: 1>Value Table file does not exist",
 					"INFO: 1>Save Generate Input file",
 					"INFO: 1>Checking for existing Generate Operation Results",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor",
 					"INFO: 1>Operation results file does not exist",
 					"INFO: 1>No previous results found",
@@ -333,7 +333,7 @@ namespace Soup::Core::UnitTests {
 					"HIGH: 1>Generate Core: [C++]my-package",
 					std::format(
 						"DIAG: 1>Execute: [C:/WorkingDirectory/my-package/] {0} true "
-						"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+						"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 						GetGenerateExePath()),
 					"DIAG: 1>Allowed Read Access:",
 					std::format("DIAG: 1>{0}", GetRuntimeLibraryPath()),
@@ -342,21 +342,21 @@ namespace Soup::Core::UnitTests {
 					"DIAG: 1>C:/Program Files/dotnet/",
 					"DIAG: "
 					"1>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"DIAG: 1>C:/WorkingDirectory/my-package/",
-					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"DIAG: 1>Allowed Write Access:",
-					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"DIAG: 1>Worker thread end 1",
 					"DIAG: 1>Build evaluation end",
 					"INFO: 1>Save operation results",
 					"INFO: 1>Loading updated Generate Phase 1 Result",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
 					"DIAG: 1>Map previous operation graph observed results",
 					"INFO: 1>Create Directory: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 					"DIAG: 1>Build evaluation skipped",
 					"INFO: 1>Nothing to do.",
 				}),
@@ -399,63 +399,63 @@ namespace Soup::Core::UnitTests {
 					"C:/Users/Me/.soup/packages/Wren/soup/wren/0.5.4/",
 					"TryGetDirectoryFilesLastWriteTime: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"Exists: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/",
+					"WhSd9nSIoVKW/.soup/",
 					"CreateDirectory: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/",
+					"WhSd9nSIoVKW/.soup/",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt",
+					"WhSd9nSIoVKW/.soup/generate-input.bvt",
 					"OpenWriteBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt",
+					"WhSd9nSIoVKW/.soup/generate-input.bvt",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor",
 					"OpenWriteBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"Exists: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/temp/",
+					"WhSd9nSIoVKW/temp/",
 					"CreateDirectory: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/temp/",
+					"WhSd9nSIoVKW/temp/",
 					"TryGetDirectoryFilesLastWriteTime: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
-					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 					"CreateDirectory: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"OpenWriteBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor",
 					"OpenWriteBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
-					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 					"CreateDirectory: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 				}),
 				fileSystem->GetRequests(),
 				"Verify file system requests match expected.");
@@ -475,7 +475,7 @@ namespace Soup::Core::UnitTests {
 						"CreateMonitorProcess: 1 [C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/] "
 						"{0} true "
 						"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-						"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/ Environment [2] 1 0 AllowedRead [7] "
+						"WhSd9nSIoVKW/.soup/ Environment [2] 1 0 AllowedRead [7] "
 						"AllowedWrite [1]",
 						GetGenerateExePath()),
 					"ProcessStart: 1",
@@ -485,7 +485,7 @@ namespace Soup::Core::UnitTests {
 					"GetExitCode: 1",
 					std::format(
 						"CreateMonitorProcess: 2 [C:/WorkingDirectory/my-package/] {0} true "
-						"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/ "
+						"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/ "
 						"Environment [2] 1 0 AllowedRead [7] AllowedWrite [1]",
 						GetGenerateExePath()),
 					"ProcessStart: 2",
@@ -499,7 +499,7 @@ namespace Soup::Core::UnitTests {
 
 			// Verify files
 			auto myPackageGenerateInputMockFile = fileSystem->GetMockFile(Path(
-				"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+				"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 				"generate-input.bvt"));
 			Assert::AreEqual(
 				ValueTable(
@@ -516,7 +516,7 @@ namespace Soup::Core::UnitTests {
 												   {"SoupTargetDirectory",
 													std::string(
 														"C:/Users/Me/.soup/packages/Wren/soup/cpp/"
-														"0.8.2/out/WhSd9nSIoVKWKcq9eytmC8vaOY4/"
+														"0.8.2/out/WhSd9nSIoVKW/"
 														".soup/")},
 											   })},
 									  })},
@@ -529,7 +529,7 @@ namespace Soup::Core::UnitTests {
 								 {"/(TARGET_my-package)/",
 								  std::string(
 									  "C:/WorkingDirectory/my-package/out/"
-									  "J_HqSstV55vlb-x6RWC_hLRFRDU/")},
+									  "J_HqSstV55vl/")},
 							 })},
 						{"EvaluateReadAccess",
 						 ValueList(
@@ -548,7 +548,7 @@ namespace Soup::Core::UnitTests {
 								 {"/(BUILD_TARGET_soup|cpp)/",
 								  std::string(
 									  "C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-									  "WhSd9nSIoVKWKcq9eytmC8vaOY4/")},
+									  "WhSd9nSIoVKW/")},
 							 })},
 						{"GenerateSubGraphMacros",
 						 ValueTable(
@@ -602,7 +602,7 @@ namespace Soup::Core::UnitTests {
 				"Verify file content match expected.");
 
 			auto myPackageGenerateResultsMockFile = fileSystem->GetMockFile(Path(
-				"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+				"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 				"generate-phase1.bor"));
 			auto myPackageGenerateResults = OperationResultsReader::Deserialize(
 				myPackageGenerateResultsMockFile->Content, fileSystemState);
@@ -623,7 +623,7 @@ namespace Soup::Core::UnitTests {
 				"Verify my package generate results content match expected.");
 
 			auto soupCppGenerateInputMockFile = fileSystem->GetMockFile(Path(
-				"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/WhSd9nSIoVKWKcq9eytmC8vaOY4/"
+				"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/WhSd9nSIoVKW/"
 				".soup/generate-input.bvt"));
 			Assert::AreEqual(
 				ValueTable(
@@ -652,7 +652,7 @@ namespace Soup::Core::UnitTests {
 								 {"/(TARGET_soup|cpp)/",
 								  std::string(
 									  "C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-									  "WhSd9nSIoVKWKcq9eytmC8vaOY4/")},
+									  "WhSd9nSIoVKW/")},
 							 })},
 						{"EvaluateReadAccess",
 						 ValueList(
@@ -730,7 +730,7 @@ namespace Soup::Core::UnitTests {
 				"Verify file content match expected.");
 
 			auto soupCppGenerateResultsMockFile = fileSystem->GetMockFile(Path(
-				"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/WhSd9nSIoVKWKcq9eytmC8vaOY4/"
+				"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/WhSd9nSIoVKW/"
 				".soup/generate-phase1.bor"));
 			auto soupCppGenerateResults = OperationResultsReader::Deserialize(
 				soupCppGenerateResultsMockFile->Content, fileSystemState);
@@ -777,15 +777,15 @@ namespace Soup::Core::UnitTests {
 				})));
 
 			fileSystem->CreateMockDirectory(
-				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/"),
+				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vl/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			fileSystem->CreateMockDirectory(
-				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"),
+				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			fileSystem->CreateMockDirectory(
-				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/"),
+				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			fileSystem->CreateMockDirectory(
@@ -803,19 +803,19 @@ namespace Soup::Core::UnitTests {
 			fileSystem->CreateMockDirectory(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/"),
+					"WhSd9nSIoVKW/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			fileSystem->CreateMockDirectory(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/"),
+					"WhSd9nSIoVKW/.soup/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			fileSystem->CreateMockDirectory(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/temp/"),
+					"WhSd9nSIoVKW/temp/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			// Create the Recipe to build
@@ -903,7 +903,7 @@ namespace Soup::Core::UnitTests {
 				myPackageGenerateResultContent);
 			fileSystem->CreateMockFile(
 				Path(
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr"),
 				std::make_shared<MockFile>(std::move(myPackageGenerateResultContent)));
 
@@ -916,7 +916,7 @@ namespace Soup::Core::UnitTests {
 			fileSystem->CreateMockFile(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr"),
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr"),
 				std::make_shared<MockFile>(std::move(soupCppGenerateResultContent)));
 
 			auto soupCppGenerateInput = ValueTable(
@@ -945,7 +945,7 @@ namespace Soup::Core::UnitTests {
 							 {"/(TARGET_soup|cpp)/",
 							  std::string(
 								  "C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-								  "WhSd9nSIoVKWKcq9eytmC8vaOY4/")},
+								  "WhSd9nSIoVKW/")},
 						 })},
 					{"EvaluateReadAccess",
 					 ValueList(
@@ -1022,7 +1022,7 @@ namespace Soup::Core::UnitTests {
 			fileSystem->CreateMockFile(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt"),
+					"WhSd9nSIoVKW/.soup/generate-input.bvt"),
 				std::make_shared<MockFile>(std::move(soupCppGenerateInputContent)));
 
 			auto myPackageGenerateInput = ValueTable(
@@ -1039,7 +1039,7 @@ namespace Soup::Core::UnitTests {
 											   {"SoupTargetDirectory",
 												std::string(
 													"C:/Users/Me/.soup/packages/Wren/soup/cpp/"
-													"0.8.2/out/WhSd9nSIoVKWKcq9eytmC8vaOY4/"
+													"0.8.2/out/WhSd9nSIoVKW/"
 													".soup/")},
 										   })},
 								  })},
@@ -1052,7 +1052,7 @@ namespace Soup::Core::UnitTests {
 							 {"/(TARGET_my-package)/",
 							  std::string(
 								  "C:/WorkingDirectory/my-package/out/"
-								  "J_HqSstV55vlb-x6RWC_hLRFRDU/")},
+								  "J_HqSstV55vl/")},
 						 })},
 					{"EvaluateReadAccess",
 					 ValueList(
@@ -1071,7 +1071,7 @@ namespace Soup::Core::UnitTests {
 							 {"/(BUILD_TARGET_soup|cpp)/",
 							  std::string(
 								  "C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-								  "WhSd9nSIoVKWKcq9eytmC8vaOY4/")},
+								  "WhSd9nSIoVKW/")},
 						 })},
 					{"GenerateSubGraphMacros",
 					 ValueTable(
@@ -1124,7 +1124,7 @@ namespace Soup::Core::UnitTests {
 			ValueTableWriter::Serialize(myPackageGenerateInput, myPackageGenerateInputContent);
 			fileSystem->CreateMockFile(
 				Path(
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt"),
 				std::make_shared<MockFile>(std::move(myPackageGenerateInputContent)));
 
@@ -1148,7 +1148,7 @@ namespace Soup::Core::UnitTests {
 				myPackageGenerateResultsContent);
 			fileSystem->CreateMockFile(
 				Path(
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor"),
 				std::make_shared<MockFile>(std::move(myPackageGenerateResultsContent)));
 
@@ -1173,7 +1173,7 @@ namespace Soup::Core::UnitTests {
 			fileSystem->CreateMockFile(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor"),
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor"),
 				std::make_shared<MockFile>(std::move(soupCppGenerateResultsContent)));
 
 			auto soupCppEvaluateResults = OperationResults();
@@ -1187,7 +1187,7 @@ namespace Soup::Core::UnitTests {
 			fileSystem->CreateMockFile(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/evaluate-phase1.bor"),
+					"WhSd9nSIoVKW/.soup/evaluate-phase1.bor"),
 				std::make_shared<MockFile>(std::move(soupCppEvaluateResultsContent)));
 
 			auto myPackageEvaluateResults = OperationResults();
@@ -1200,7 +1200,7 @@ namespace Soup::Core::UnitTests {
 				myPackageEvaluateResultsContent);
 			fileSystem->CreateMockFile(
 				Path(
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"evaluate-phase1.bor"),
 				std::make_shared<MockFile>(std::move(myPackageEvaluateResultsContent)));
 
@@ -1257,20 +1257,20 @@ namespace Soup::Core::UnitTests {
 					"INFO: 2>Checking for existing Generate Phase 1 Result",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"INFO: 2>Phase1 previous graph found",
 					"INFO: 2>Checking for existing Evaluate Operation Results",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/evaluate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/evaluate-phase1.bor",
 					"INFO: 2>Phase1 previous results found",
 					"INFO: 2>Check outdated generate input file: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt",
+					"WhSd9nSIoVKW/.soup/generate-input.bvt",
 					"INFO: 2>Checking for existing Generate Operation Results",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor",
 					"INFO: 2>Previous results found",
 					"DIAG: 2>Build evaluation start 1",
 					"DIAG: 2>Worker thread start 1",
@@ -1285,20 +1285,20 @@ namespace Soup::Core::UnitTests {
 					"INFO: 1>Build 'my-package'",
 					"INFO: 1>Checking for existing Generate Phase 1 Result",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
 					"INFO: 1>Phase1 previous graph found",
 					"INFO: 1>Checking for existing Evaluate Operation Results",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"evaluate-phase1.bor",
 					"INFO: 1>Phase1 previous results found",
 					"INFO: 1>Check outdated generate input file: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"INFO: 1>Checking for existing Generate Operation Results",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor",
 					"INFO: 1>Previous results found",
 					"DIAG: 1>Build evaluation start 1",
@@ -1347,42 +1347,42 @@ namespace Soup::Core::UnitTests {
 					"C:/Users/Me/.soup/packages/Wren/soup/wren/0.5.4/",
 					"TryGetDirectoryFilesLastWriteTime: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/evaluate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/evaluate-phase1.bor",
 					"Exists: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/",
+					"WhSd9nSIoVKW/.soup/",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt",
+					"WhSd9nSIoVKW/.soup/generate-input.bvt",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor",
 					std::format("TryGetLastWriteTime: {0}", GetGenerateExePath()),
 					"Exists: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/temp/",
+					"WhSd9nSIoVKW/temp/",
 					"TryGetDirectoryFilesLastWriteTime: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"evaluate-phase1.bor",
-					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor",
-					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 				}),
 				fileSystem->GetRequests(),
 				"Verify file system requests match expected.");
@@ -1521,7 +1521,7 @@ namespace Soup::Core::UnitTests {
 			monitorProcessManager->RegisterExecuteCallback(
 				std::format(
 					"CreateMonitorProcess: 2 [C:/WorkingDirectory/my-package/] {0} true "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/ "
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/ "
 					"Environment [2] 1 0 AllowedRead [7] AllowedWrite [1]",
 					GetGenerateExePath()),
 				[&](Monitor::ISystemAccessMonitor & /*monitor*/) {
@@ -1537,7 +1537,7 @@ namespace Soup::Core::UnitTests {
 						myPackageGenerateResultContent);
 					fileSystem->CreateMockFile(
 						Path(
-							"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+							"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 							"generate-phase1.bgr"),
 						std::make_shared<MockFile>(std::move(myPackageGenerateResultContent)));
 				});
@@ -1545,7 +1545,7 @@ namespace Soup::Core::UnitTests {
 			monitorProcessManager->RegisterExecuteCallback(
 				std::format(
 					"CreateMonitorProcess: 3 [C:/WorkingDirectory/my-package/] {0} false "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/ "
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/ "
 					"Environment [2] 1 0 AllowedRead [7] AllowedWrite [1]",
 					GetGenerateExePath()),
 				[&](Monitor::ISystemAccessMonitor & /*monitor*/) {
@@ -1560,7 +1560,7 @@ namespace Soup::Core::UnitTests {
 						myPackageOperationGraphContent);
 					fileSystem->CreateMockFile(
 						Path(
-							"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+							"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 							"generate-phase2.bog"),
 						std::make_shared<MockFile>(std::move(myPackageOperationGraphContent)));
 				});
@@ -1570,7 +1570,7 @@ namespace Soup::Core::UnitTests {
 					"CreateMonitorProcess: 1 [C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/] {0} "
 					"true "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/ Environment [2] 1 0 AllowedRead [7] "
+					"WhSd9nSIoVKW/.soup/ Environment [2] 1 0 AllowedRead [7] "
 					"AllowedWrite [1]",
 					GetGenerateExePath()),
 				[&](Monitor::ISystemAccessMonitor & /*monitor*/) {
@@ -1587,7 +1587,7 @@ namespace Soup::Core::UnitTests {
 					fileSystem->CreateMockFile(
 						Path(
 							"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-							"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr"),
+							"WhSd9nSIoVKW/.soup/generate-phase1.bgr"),
 						std::make_shared<MockFile>(std::move(soupCppGenerateResultContent)));
 				});
 
@@ -1634,25 +1634,25 @@ namespace Soup::Core::UnitTests {
 					"INFO: 2>Build 'soup|cpp'",
 					"INFO: 2>Preload Directory Missing: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"INFO: 2>Checking for existing Generate Phase 1 Result",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"INFO: 2>Generate result file does not exist",
 					"INFO: 2>Phase1 no previous graph",
 					"INFO: 2>Create Directory: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/",
+					"WhSd9nSIoVKW/.soup/",
 					"INFO: 2>Check outdated generate input file: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt",
+					"WhSd9nSIoVKW/.soup/generate-input.bvt",
 					"INFO: 2>Value Table file does not exist",
 					"INFO: 2>Save Generate Input file",
 					"INFO: 2>Checking for existing Generate Operation Results",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor",
 					"INFO: 2>Operation results file does not exist",
 					"INFO: 2>No previous results found",
 					"DIAG: 2>Build evaluation start 1",
@@ -1664,7 +1664,7 @@ namespace Soup::Core::UnitTests {
 						"DIAG: 2>Execute: [C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/] {0} "
 						"true "
 						"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-						"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/",
+						"WhSd9nSIoVKW/.soup/",
 						GetGenerateExePath()),
 					"DIAG: 2>Allowed Read Access:",
 					std::format("DIAG: 2>{0}", GetRuntimeLibraryPath()),
@@ -1675,44 +1675,44 @@ namespace Soup::Core::UnitTests {
 					"DIAG: 2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"DIAG: 2>Allowed Write Access:",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"DIAG: 2>Worker thread end 1",
 					"DIAG: 2>Build evaluation end",
 					"INFO: 2>Save operation results",
 					"INFO: 2>Loading updated Generate Phase 1 Result",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"DIAG: 2>Map previous operation graph observed results",
 					"INFO: 2>Create Directory: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/temp/",
+					"WhSd9nSIoVKW/temp/",
 					"DIAG: 2>Build evaluation skipped",
 					"INFO: 2>Nothing to do.",
 					"DIAG: 1>Running Build: [C++]my-package",
 					"INFO: 1>Build 'my-package'",
 					"INFO: 1>Preload Directory Missing: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"INFO: 1>Checking for existing Generate Phase 1 Result",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
 					"INFO: 1>Generate result file does not exist",
 					"INFO: 1>Phase1 no previous graph",
 					"INFO: 1>Create Directory: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 					"INFO: 1>Check outdated generate input file: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"INFO: 1>Value Table file does not exist",
 					"INFO: 1>Save Generate Input file",
 					"INFO: 1>Checking for existing Generate Operation Results",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor",
 					"INFO: 1>Operation results file does not exist",
 					"INFO: 1>No previous results found",
@@ -1723,7 +1723,7 @@ namespace Soup::Core::UnitTests {
 					"HIGH: 1>Generate Core: [C++]my-package",
 					std::format(
 						"DIAG: 1>Execute: [C:/WorkingDirectory/my-package/] {0} true "
-						"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+						"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 						GetGenerateExePath()),
 					"DIAG: 1>Allowed Read Access:",
 					std::format("DIAG: 1>{0}", GetRuntimeLibraryPath()),
@@ -1732,28 +1732,28 @@ namespace Soup::Core::UnitTests {
 					"DIAG: 1>C:/Program Files/dotnet/",
 					"DIAG: "
 					"1>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"DIAG: 1>C:/WorkingDirectory/my-package/",
-					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"DIAG: 1>Allowed Write Access:",
-					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"DIAG: 1>Worker thread end 1",
 					"DIAG: 1>Build evaluation end",
 					"INFO: 1>Save operation results",
 					"INFO: 1>Loading updated Generate Phase 1 Result",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
 					"DIAG: 1>Map previous operation graph observed results",
 					"INFO: 1>Create Directory: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 					"DIAG: 1>Build evaluation skipped",
 					"INFO: 1>Check outdated generate input file: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"INFO: 1>Checking for existing Generate Operation Results",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase2.bor",
 					"INFO: 1>Operation results file does not exist",
 					"INFO: 1>No previous results found",
@@ -1764,7 +1764,7 @@ namespace Soup::Core::UnitTests {
 					"HIGH: 1>Generate Core: [C++]my-package",
 					std::format(
 						"DIAG: 1>Execute: [C:/WorkingDirectory/my-package/] {0} false "
-						"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+						"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 						GetGenerateExePath()),
 					"DIAG: 1>Allowed Read Access:",
 					std::format("DIAG: 1>{0}", GetRuntimeLibraryPath()),
@@ -1773,18 +1773,18 @@ namespace Soup::Core::UnitTests {
 					"DIAG: 1>C:/Program Files/dotnet/",
 					"DIAG: "
 					"1>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"DIAG: 1>C:/WorkingDirectory/my-package/",
-					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"DIAG: 1>Allowed Write Access:",
-					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"DIAG: 1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"DIAG: 1>Worker thread end 1",
 					"DIAG: 1>Build evaluation end",
 					"INFO: 1>Save operation results",
 					"INFO: 1>Load update Generate Phase 2 Result",
 					"DIAG: 1>Map previous operation graph observed results",
 					"INFO: 1>Create Directory: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 					"DIAG: 1>Build evaluation skipped",
 					"INFO: 1>Nothing to do.",
 				}),
@@ -1828,78 +1828,78 @@ namespace Soup::Core::UnitTests {
 					"C:/Users/Me/.soup/packages/Wren/soup/wren/0.5.4/",
 					"TryGetDirectoryFilesLastWriteTime: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"Exists: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/",
+					"WhSd9nSIoVKW/.soup/",
 					"CreateDirectory: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/",
+					"WhSd9nSIoVKW/.soup/",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt",
+					"WhSd9nSIoVKW/.soup/generate-input.bvt",
 					"OpenWriteBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt",
+					"WhSd9nSIoVKW/.soup/generate-input.bvt",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor",
 					"OpenWriteBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"Exists: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/temp/",
+					"WhSd9nSIoVKW/temp/",
 					"CreateDirectory: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/temp/",
+					"WhSd9nSIoVKW/temp/",
 					"TryGetDirectoryFilesLastWriteTime: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
-					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 					"CreateDirectory: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"OpenWriteBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor",
 					"OpenWriteBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
-					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 					"CreateDirectory: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase2.bor",
 					"OpenWriteBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase2.bor",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase2.bog",
-					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 					"CreateDirectory: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 				}),
 				fileSystem->GetRequests(),
 				"Verify file system requests match expected.");
@@ -1920,7 +1920,7 @@ namespace Soup::Core::UnitTests {
 						"CreateMonitorProcess: 1 [C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/] "
 						"{0} true "
 						"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-						"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/ Environment [2] 1 0 AllowedRead [7] "
+						"WhSd9nSIoVKW/.soup/ Environment [2] 1 0 AllowedRead [7] "
 						"AllowedWrite [1]",
 						GetGenerateExePath()),
 					"ProcessStart: 1",
@@ -1930,7 +1930,7 @@ namespace Soup::Core::UnitTests {
 					"GetExitCode: 1",
 					std::format(
 						"CreateMonitorProcess: 2 [C:/WorkingDirectory/my-package/] {0} true "
-						"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/ "
+						"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/ "
 						"Environment [2] 1 0 AllowedRead [7] AllowedWrite [1]",
 						GetGenerateExePath()),
 					"ProcessStart: 2",
@@ -1940,7 +1940,7 @@ namespace Soup::Core::UnitTests {
 					"GetExitCode: 2",
 					std::format(
 						"CreateMonitorProcess: 3 [C:/WorkingDirectory/my-package/] {0} false "
-						"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/ "
+						"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/ "
 						"Environment [2] 1 0 AllowedRead [7] AllowedWrite [1]",
 						GetGenerateExePath()),
 					"ProcessStart: 3",
@@ -1954,7 +1954,7 @@ namespace Soup::Core::UnitTests {
 
 			// Verify files
 			auto myPackageGenerateInputMockFile = fileSystem->GetMockFile(Path(
-				"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+				"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 				"generate-input.bvt"));
 			Assert::AreEqual(
 				ValueTable(
@@ -1971,7 +1971,7 @@ namespace Soup::Core::UnitTests {
 												   {"SoupTargetDirectory",
 													std::string(
 														"C:/Users/Me/.soup/packages/Wren/soup/cpp/"
-														"0.8.2/out/WhSd9nSIoVKWKcq9eytmC8vaOY4/"
+														"0.8.2/out/WhSd9nSIoVKW/"
 														".soup/")},
 											   })},
 									  })},
@@ -1984,7 +1984,7 @@ namespace Soup::Core::UnitTests {
 								 {"/(TARGET_my-package)/",
 								  std::string(
 									  "C:/WorkingDirectory/my-package/out/"
-									  "J_HqSstV55vlb-x6RWC_hLRFRDU/")},
+									  "J_HqSstV55vl/")},
 							 })},
 						{"EvaluateReadAccess",
 						 ValueList(
@@ -2003,7 +2003,7 @@ namespace Soup::Core::UnitTests {
 								 {"/(BUILD_TARGET_soup|cpp)/",
 								  std::string(
 									  "C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-									  "WhSd9nSIoVKWKcq9eytmC8vaOY4/")},
+									  "WhSd9nSIoVKW/")},
 							 })},
 						{"GenerateSubGraphMacros",
 						 ValueTable(
@@ -2057,7 +2057,7 @@ namespace Soup::Core::UnitTests {
 				"Verify file content match expected.");
 
 			auto myPackageGenerateResultsMockFile = fileSystem->GetMockFile(Path(
-				"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+				"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 				"generate-phase1.bor"));
 			auto myPackageGenerateResults = OperationResultsReader::Deserialize(
 				myPackageGenerateResultsMockFile->Content, fileSystemState);
@@ -2078,7 +2078,7 @@ namespace Soup::Core::UnitTests {
 				"Verify my package generate results content match expected.");
 
 			auto soupCppGenerateInputMockFile = fileSystem->GetMockFile(Path(
-				"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/WhSd9nSIoVKWKcq9eytmC8vaOY4/"
+				"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/WhSd9nSIoVKW/"
 				".soup/generate-input.bvt"));
 			Assert::AreEqual(
 				ValueTable(
@@ -2107,7 +2107,7 @@ namespace Soup::Core::UnitTests {
 								 {"/(TARGET_soup|cpp)/",
 								  std::string(
 									  "C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-									  "WhSd9nSIoVKWKcq9eytmC8vaOY4/")},
+									  "WhSd9nSIoVKW/")},
 							 })},
 						{"EvaluateReadAccess",
 						 ValueList(
@@ -2185,7 +2185,7 @@ namespace Soup::Core::UnitTests {
 				"Verify file content match expected.");
 
 			auto soupCppGenerateResultsMockFile = fileSystem->GetMockFile(Path(
-				"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/WhSd9nSIoVKWKcq9eytmC8vaOY4/"
+				"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/WhSd9nSIoVKW/"
 				".soup/generate-phase1.bor"));
 			auto soupCppGenerateResults = OperationResultsReader::Deserialize(
 				soupCppGenerateResultsMockFile->Content, fileSystemState);
@@ -2232,15 +2232,15 @@ namespace Soup::Core::UnitTests {
 				})));
 
 			fileSystem->CreateMockDirectory(
-				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/"),
+				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vl/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			fileSystem->CreateMockDirectory(
-				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"),
+				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			fileSystem->CreateMockDirectory(
-				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/"),
+				Path("C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			fileSystem->CreateMockDirectory(
@@ -2258,19 +2258,19 @@ namespace Soup::Core::UnitTests {
 			fileSystem->CreateMockDirectory(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/"),
+					"WhSd9nSIoVKW/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			fileSystem->CreateMockDirectory(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/"),
+					"WhSd9nSIoVKW/.soup/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			fileSystem->CreateMockDirectory(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/temp/"),
+					"WhSd9nSIoVKW/temp/"),
 				std::make_shared<MockDirectory>(std::vector<Path>({})));
 
 			// Create the Recipe to build
@@ -2358,7 +2358,7 @@ namespace Soup::Core::UnitTests {
 				myPackageGenerateResultContent);
 			fileSystem->CreateMockFile(
 				Path(
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr"),
 				std::make_shared<MockFile>(std::move(myPackageGenerateResultContent)));
 
@@ -2371,7 +2371,7 @@ namespace Soup::Core::UnitTests {
 			fileSystem->CreateMockFile(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr"),
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr"),
 				std::make_shared<MockFile>(std::move(soupCppGenerateResultContent)));
 
 			auto soupCppGenerateInput = ValueTable(
@@ -2400,7 +2400,7 @@ namespace Soup::Core::UnitTests {
 							 {"/(TARGET_soup|cpp)/",
 							  std::string(
 								  "C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-								  "WhSd9nSIoVKWKcq9eytmC8vaOY4/")},
+								  "WhSd9nSIoVKW/")},
 						 })},
 					{"EvaluateReadAccess",
 					 ValueList(
@@ -2477,7 +2477,7 @@ namespace Soup::Core::UnitTests {
 			fileSystem->CreateMockFile(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt"),
+					"WhSd9nSIoVKW/.soup/generate-input.bvt"),
 				std::make_shared<MockFile>(std::move(soupCppGenerateInputContent)));
 
 			auto myPackageGenerateInput = ValueTable(
@@ -2494,7 +2494,7 @@ namespace Soup::Core::UnitTests {
 											   {"SoupTargetDirectory",
 												std::string(
 													"C:/Users/Me/.soup/packages/Wren/soup/cpp/"
-													"0.8.2/out/WhSd9nSIoVKWKcq9eytmC8vaOY4/"
+													"0.8.2/out/WhSd9nSIoVKW/"
 													".soup/")},
 										   })},
 								  })},
@@ -2507,7 +2507,7 @@ namespace Soup::Core::UnitTests {
 							 {"/(TARGET_my-package)/",
 							  std::string(
 								  "C:/WorkingDirectory/my-package/out/"
-								  "J_HqSstV55vlb-x6RWC_hLRFRDU/")},
+								  "J_HqSstV55vl/")},
 						 })},
 					{"EvaluateReadAccess",
 					 ValueList(
@@ -2526,7 +2526,7 @@ namespace Soup::Core::UnitTests {
 							 {"/(BUILD_TARGET_soup|cpp)/",
 							  std::string(
 								  "C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-								  "WhSd9nSIoVKWKcq9eytmC8vaOY4/")},
+								  "WhSd9nSIoVKW/")},
 						 })},
 					{"GenerateSubGraphMacros",
 					 ValueTable(
@@ -2579,7 +2579,7 @@ namespace Soup::Core::UnitTests {
 			ValueTableWriter::Serialize(myPackageGenerateInput, myPackageGenerateInputContent);
 			fileSystem->CreateMockFile(
 				Path(
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt"),
 				std::make_shared<MockFile>(std::move(myPackageGenerateInputContent)));
 
@@ -2603,7 +2603,7 @@ namespace Soup::Core::UnitTests {
 				myPackageGeneratePhase1ResultsContent);
 			fileSystem->CreateMockFile(
 				Path(
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor"),
 				std::make_shared<MockFile>(std::move(myPackageGeneratePhase1ResultsContent)));
 
@@ -2616,7 +2616,7 @@ namespace Soup::Core::UnitTests {
 				myPackageGeneratePhase2ResultsContent);
 			fileSystem->CreateMockFile(
 				Path(
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase2.bor"),
 				std::make_shared<MockFile>(std::move(myPackageGeneratePhase2ResultsContent)));
 
@@ -2641,7 +2641,7 @@ namespace Soup::Core::UnitTests {
 			fileSystem->CreateMockFile(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor"),
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor"),
 				std::make_shared<MockFile>(std::move(soupCppGenerateResultsContent)));
 
 			auto soupCppEvaluateResults = OperationResults();
@@ -2655,7 +2655,7 @@ namespace Soup::Core::UnitTests {
 			fileSystem->CreateMockFile(
 				Path(
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/evaluate-phase1.bor"),
+					"WhSd9nSIoVKW/.soup/evaluate-phase1.bor"),
 				std::make_shared<MockFile>(std::move(soupCppEvaluateResultsContent)));
 
 			auto myPackageEvaluateResults = OperationResults();
@@ -2668,7 +2668,7 @@ namespace Soup::Core::UnitTests {
 				myPackageEvaluateResultsContent);
 			fileSystem->CreateMockFile(
 				Path(
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"evaluate-phase1.bor"),
 				std::make_shared<MockFile>(std::move(myPackageEvaluateResultsContent)));
 
@@ -2725,20 +2725,20 @@ namespace Soup::Core::UnitTests {
 					"INFO: 2>Checking for existing Generate Phase 1 Result",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"INFO: 2>Phase1 previous graph found",
 					"INFO: 2>Checking for existing Evaluate Operation Results",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/evaluate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/evaluate-phase1.bor",
 					"INFO: 2>Phase1 previous results found",
 					"INFO: 2>Check outdated generate input file: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt",
+					"WhSd9nSIoVKW/.soup/generate-input.bvt",
 					"INFO: 2>Checking for existing Generate Operation Results",
 					"DIAG: "
 					"2>C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor",
 					"INFO: 2>Previous results found",
 					"DIAG: 2>Build evaluation start 1",
 					"DIAG: 2>Worker thread start 1",
@@ -2753,26 +2753,26 @@ namespace Soup::Core::UnitTests {
 					"INFO: 1>Build 'my-package'",
 					"INFO: 1>Checking for existing Generate Phase 1 Result",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
 					"INFO: 1>Phase1 previous graph found",
 					"INFO: 1>Checking for existing Evaluate Operation Results",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"evaluate-phase1.bor",
 					"INFO: 1>Phase1 previous results found",
 					"INFO: 1>Checking for existing Generate Phase 2 Result",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase2.bog",
 					"INFO: 1>Operation graph file does not exist",
 					"INFO: 1>Phase2 no previous graph",
 					"INFO: 1>Check outdated generate input file: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"INFO: 1>Checking for existing Generate Operation Results",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor",
 					"INFO: 1>Previous results found",
 					"DIAG: 1>Build evaluation start 1",
@@ -2784,11 +2784,11 @@ namespace Soup::Core::UnitTests {
 					"DIAG: 1>Build evaluation end",
 					"DIAG: 1>Build evaluation skipped",
 					"INFO: 1>Check outdated generate input file: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"INFO: 1>Checking for existing Generate Operation Results",
 					"DIAG: "
-					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"1>C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase2.bor",
 					"INFO: 1>Previous results found",
 					"DIAG: 1>Build evaluation start 1",
@@ -2837,52 +2837,52 @@ namespace Soup::Core::UnitTests {
 					"C:/Users/Me/.soup/packages/Wren/soup/wren/0.5.4/",
 					"TryGetDirectoryFilesLastWriteTime: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/",
+					"WhSd9nSIoVKW/",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bgr",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bgr",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/evaluate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/evaluate-phase1.bor",
 					"Exists: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/",
+					"WhSd9nSIoVKW/.soup/",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-input.bvt",
+					"WhSd9nSIoVKW/.soup/generate-input.bvt",
 					"TryOpenReadBinary: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/.soup/generate-phase1.bor",
+					"WhSd9nSIoVKW/.soup/generate-phase1.bor",
 					std::format("TryGetLastWriteTime: {0}", GetGenerateExePath()),
 					"Exists: "
 					"C:/Users/Me/.soup/packages/Wren/soup/cpp/0.8.2/out/"
-					"WhSd9nSIoVKWKcq9eytmC8vaOY4/temp/",
+					"WhSd9nSIoVKW/temp/",
 					"TryGetDirectoryFilesLastWriteTime: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/",
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bgr",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"evaluate-phase1.bor",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase2.bog",
-					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/",
+					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase1.bor",
-					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-input.bvt",
 					"TryOpenReadBinary: "
-					"C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/.soup/"
+					"C:/WorkingDirectory/my-package/out/J_HqSstV55vl/.soup/"
 					"generate-phase2.bor",
-					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vlb-x6RWC_hLRFRDU/temp/",
+					"Exists: C:/WorkingDirectory/my-package/out/J_HqSstV55vl/temp/",
 				}),
 				fileSystem->GetRequests(),
 				"Verify file system requests match expected.");

--- a/code/client/core/tests/build/recipe-build-location-manager-tests.cpp
+++ b/code/client/core/tests/build/recipe-build-location-manager-tests.cpp
@@ -55,7 +55,7 @@ namespace Soup::Core::UnitTests {
 				packageName, workingDirectory, recipe, globalParameters, recipeCache);
 
 			Assert::AreEqual(
-				Path("C:/WorkingDirectory/out/J_HqSstV55vlb-x6RWC_hLRFRDU/"),
+				Path("C:/WorkingDirectory/out/J_HqSstV55vl/"),
 				targetDirectory,
 				"Verify target directory matches expected.");
 
@@ -101,7 +101,7 @@ namespace Soup::Core::UnitTests {
 				packageName, workingDirectory, recipe, globalParameters, recipeCache);
 
 			Assert::AreEqual(
-				Path("C:/BuildOut/cpp/local/my-package/1.2.3/J_HqSstV55vlb-x6RWC_hLRFRDU/"),
+				Path("C:/BuildOut/cpp/local/my-package/1.2.3/J_HqSstV55vl/"),
 				targetDirectory,
 				"Verify target directory matches expected.");
 

--- a/code/client/native/package-lock.sml
+++ b/code/client/native/package-lock.sml
@@ -7,7 +7,7 @@ Closure: {
 	'C++': {
 		'monitor-host': { Version: '../../monitor/host/', Build: '0', Tool: '0' }
 		'monitor-shared': { Version: '../../monitor/shared/', Build: '0', Tool: '0' }
-		'mwasplund|cryptopp': { Version: 1.2.9, Digest: 'sha256:53e593acbdfcaa81f285bcb64dabc3d38f36fd9bff7168d3c10a5d9ef752f446', Build: '0', Tool: '0' }
+		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|json11': { Version: 1.1.6, Digest: 'sha256:c6b0981921f926b73e9512d068efde6eb2c5183f6b3a8442bddc67f847d2bfc4', Build: '0', Tool: '0' }
 		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }

--- a/code/client/native/package-lock.sml
+++ b/code/client/native/package-lock.sml
@@ -10,7 +10,7 @@ Closure: {
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|json11': { Version: 1.1.6, Digest: 'sha256:c6b0981921f926b73e9512d068efde6eb2c5183f6b3a8442bddc67f847d2bfc4', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../../sml/', Build: '0', Tool: '0' }

--- a/code/client/native/package-lock.sml
+++ b/code/client/native/package-lock.sml
@@ -10,7 +10,7 @@ Closure: {
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|json11': { Version: 1.1.6, Digest: 'sha256:c6b0981921f926b73e9512d068efde6eb2c5183f6b3a8442bddc67f847d2bfc4', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.8, Digest: 'sha256:a43a45de9efabdc5b6d204302d4309d00ab3c21d3cce0cfc2f136b1c652376b1', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../../sml/', Build: '0', Tool: '0' }

--- a/code/generate-sharp/soup-native-interop/soup.native.interop.csproj
+++ b/code/generate-sharp/soup-native-interop/soup.native.interop.csproj
@@ -4,10 +4,10 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
-		<SoupConfigHash>OZlIVjblazFuKXg-raWUNoGEnG4</SoupConfigHash>
+		<SoupConfigHash>OZlIVjblazFu</SoupConfigHash>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
-		<SoupConfigHash>Oltq7cGwk0Rbgy1I-3mCMDDE5yM</SoupConfigHash>
+		<SoupConfigHash>Oltq7cGwk0Rb</SoupConfigHash>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(OS)'=='Windows_NT'">
 		<SoupNativeDll>soup-native.dll</SoupNativeDll>

--- a/code/generate-test/package-lock.sml
+++ b/code/generate-test/package-lock.sml
@@ -9,7 +9,7 @@ Closure: {
 		'monitor-shared': { Version: '../monitor/shared/', Build: '0', Tool: '0' }
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../sml/', Build: '0', Tool: '0' }

--- a/code/generate-test/package-lock.sml
+++ b/code/generate-test/package-lock.sml
@@ -9,7 +9,7 @@ Closure: {
 		'monitor-shared': { Version: '../monitor/shared/', Build: '0', Tool: '0' }
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.8, Digest: 'sha256:a43a45de9efabdc5b6d204302d4309d00ab3c21d3cce0cfc2f136b1c652376b1', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../sml/', Build: '0', Tool: '0' }

--- a/code/generate-test/package-lock.sml
+++ b/code/generate-test/package-lock.sml
@@ -7,7 +7,7 @@ Closure: {
 	'C++': {
 		'monitor-host': { Version: '../monitor/host/', Build: '0', Tool: '0' }
 		'monitor-shared': { Version: '../monitor/shared/', Build: '0', Tool: '0' }
-		'mwasplund|cryptopp': { Version: 1.2.9, Digest: 'sha256:53e593acbdfcaa81f285bcb64dabc3d38f36fd9bff7168d3c10a5d9ef752f446', Build: '0', Tool: '0' }
+		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }

--- a/code/generate/package-lock.sml
+++ b/code/generate/package-lock.sml
@@ -9,7 +9,7 @@ Closure: {
 		'monitor-shared': { Version: '../monitor/shared/', Build: '0', Tool: '0' }
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../sml/', Build: '0', Tool: '0' }

--- a/code/generate/package-lock.sml
+++ b/code/generate/package-lock.sml
@@ -9,7 +9,7 @@ Closure: {
 		'monitor-shared': { Version: '../monitor/shared/', Build: '0', Tool: '0' }
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.8, Digest: 'sha256:a43a45de9efabdc5b6d204302d4309d00ab3c21d3cce0cfc2f136b1c652376b1', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../sml/', Build: '0', Tool: '0' }

--- a/code/generate/package-lock.sml
+++ b/code/generate/package-lock.sml
@@ -7,7 +7,7 @@ Closure: {
 	'C++': {
 		'monitor-host': { Version: '../monitor/host/', Build: '0', Tool: '0' }
 		'monitor-shared': { Version: '../monitor/shared/', Build: '0', Tool: '0' }
-		'mwasplund|cryptopp': { Version: 1.2.9, Digest: 'sha256:53e593acbdfcaa81f285bcb64dabc3d38f36fd9bff7168d3c10a5d9ef752f446', Build: '0', Tool: '0' }
+		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }

--- a/code/installer/soup-installer/Setup.cs
+++ b/code/installer/soup-installer/Setup.cs
@@ -7,7 +7,7 @@ public static class Script
 {
 	public static void Main()
 	{
-		var soupVersion = new Version(0, 48, 0);
+		var soupVersion = new Version(0, 48, 1);
 
 		var soupOutFolder = "../../../out";
 		var soupReleaseFolder = $"{soupOutFolder}/release/{soupVersion}";

--- a/code/monitor/client/file-system-access-sandbox.h
+++ b/code/monitor/client/file-system-access-sandbox.h
@@ -8,21 +8,15 @@ namespace Monitor {
 	public:
 		static void Initialize(
 			bool enableAccessChecks,
-			Opal::Path workingDirectory,
-			std::vector<std::string> allowedReadDirectories,
-			std::vector<std::string> allowedWriteDirectories) {
+			Opal::Path&& workingDirectory,
+			std::vector<Opal::Path>&& allowedReadDirectories,
+			std::vector<Opal::Path>&& allowedWriteDirectories) {
 			connectionManager.DebugTrace("FileSystemAccessSandbox::Initialize");
 
 			m_enableAccessChecks = enableAccessChecks;
 			m_workingDirectory = std::move(workingDirectory);
-
-			m_allowedReadDirectories.clear();
-			for (auto &value : allowedReadDirectories)
-				m_allowedReadDirectories.push_back(NormalizePath(value.c_str()));
-
-			m_allowedWriteDirectories.clear();
-			for (auto &value : allowedWriteDirectories)
-				m_allowedWriteDirectories.push_back(NormalizePath(value.c_str()));
+			m_allowedReadDirectories = std::move(allowedReadDirectories);
+			m_allowedWriteDirectories = std::move(allowedWriteDirectories);
 		}
 
 		static void UpdateWorkingDirectory(const wchar_t *fileName) {
@@ -70,7 +64,7 @@ namespace Monitor {
 				}
 			}
 
-			ConnectionManagerBase::DebugTrace("Block: {} {}", fileName, normalizedFileName);
+			ConnectionManagerBase::DebugTrace("Block: {} {}", fileName, normalizedFileName.ToString());
 			return false;
 		}
 
@@ -112,25 +106,31 @@ namespace Monitor {
 			return file.starts_with("\\\\.\\");
 		}
 
-		static std::string NormalizePath(const char *fileName) {
+		static Opal::Path NormalizePath(const char *fileName) {
 			// Normalize the path separators and get absolute path
 			auto path = Opal::Path::ParseWindows(fileName);
 			if (!path.HasRoot()) {
 				path = m_workingDirectory + path;
 			}
 
-			auto result = path.ToString();
-
-			// Ignore case
-			std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) {
-				return (char)std::toupper(c);
-			});
-
-			return result;
+			return path;
 		}
 
-		static bool IsUnderDirectory(const std::string &fileName, const std::string &directory) {
-			return fileName.find(directory) == 0;
+		static bool IsUnderDirectory(const Opal::Path &fileName, const Opal::Path &directory) {
+			return StartsWithIgnoreCase(fileName.ToString(), directory.ToString());
+		}
+
+		static bool StartsWithIgnoreCase(std::string_view lhs, std::string_view rhs) {
+			// A string cannot start with a prefix longer than itself
+			if (lhs.length() < rhs.length()) {
+				return false;
+			}
+
+			// Compare characters up to the length of the prefix
+			return std::equal(rhs.begin(), rhs.end(), lhs.begin(), 
+				[](unsigned char a, unsigned char b) {
+					return std::toupper(a) == std::toupper(b);
+				});
 		}
 
 		static std::string UTF8Encode(const std::wstring_view wideString) {
@@ -164,14 +164,14 @@ namespace Monitor {
 		static bool m_enableAccessChecks;
 		static Opal::Path m_workingDirectory;
 
-		static std::vector<std::string> m_allowedReadDirectories;
-		static std::vector<std::string> m_allowedWriteDirectories;
+		static std::vector<Opal::Path> m_allowedReadDirectories;
+		static std::vector<Opal::Path> m_allowedWriteDirectories;
 	};
 
 	bool FileSystemAccessSandbox::m_enableAccessChecks = false;
 	Opal::Path FileSystemAccessSandbox::m_workingDirectory = Opal::Path();
-	std::vector<std::string> FileSystemAccessSandbox::m_allowedReadDirectories =
-		std::vector<std::string>();
-	std::vector<std::string> FileSystemAccessSandbox::m_allowedWriteDirectories =
-		std::vector<std::string>();
+	std::vector<Opal::Path> FileSystemAccessSandbox::m_allowedReadDirectories =
+		std::vector<Opal::Path>();
+	std::vector<Opal::Path> FileSystemAccessSandbox::m_allowedWriteDirectories =
+		std::vector<Opal::Path>();
 }

--- a/code/monitor/client/package-lock.sml
+++ b/code/monitor/client/package-lock.sml
@@ -4,7 +4,7 @@ Closure: {
 		'monitor-client': { Version: './', Build: '0', Tool: '0' }
 		'monitor-shared': { Version: '../shared/', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
 	}
 }
 Builds: {

--- a/code/monitor/client/package-lock.sml
+++ b/code/monitor/client/package-lock.sml
@@ -4,7 +4,7 @@ Closure: {
 		'monitor-client': { Version: './', Build: '0', Tool: '0' }
 		'monitor-shared': { Version: '../shared/', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.8, Digest: 'sha256:a43a45de9efabdc5b6d204302d4309d00ab3c21d3cce0cfc2f136b1c652376b1', Build: '0', Tool: '0' }
 	}
 }
 Builds: {

--- a/code/monitor/client/windows/attach-detours.h
+++ b/code/monitor/client/windows/attach-detours.h
@@ -1994,20 +1994,9 @@ namespace Monitor::Windows {
 		return true;
 	}
 
-	std::vector<std::string> ExtractStringList(const char *rawValues, uint64_t length) {
-		auto result = std::vector<std::string>();
-		auto remainingContent = length;
-		auto valueBuffer = rawValues;
-
-		// Keep pulling off strings until we reach the end
-		while (remainingContent > 0) {
-			auto value = std::string(valueBuffer);
-			valueBuffer += value.length() + 1;
-			remainingContent -= value.length() + 1;
-
-			result.push_back(std::move(value));
-		}
-
+	std::vector<Opal::Path> ExtractStringList(const char *rawValues, size_t length) {
+		auto set = Opal::PathSet::Deserialize(rawValues, length);
+		auto result = set.GetPaths();
 		return result;
 	}
 

--- a/code/monitor/host/windows/windows-monitor-process.h
+++ b/code/monitor/host/windows/windows-monitor-process.h
@@ -438,25 +438,24 @@ namespace Monitor::Windows {
 
 			auto set = PathSet::Build(values);
 
+			// TODO: Serialize directly to the buffer
 			auto stream = std::stringstream();
 			set.Serialize(stream);
 
-			std::cout << "S1: " << stream.str().size() << std::endl;
+			length = static_cast<unsigned long>(stream.str().size());
+			if (length > maxLength)
+				throw std::runtime_error("Ran out of space in payload string list");
+			stream.str().copy(rawValues, length);
+		}
 
-			for (auto value : values) {
-				auto stringValue = value.ToString();
-				auto newLength = length + static_cast<unsigned long>(stringValue.length()) + 1;
-				if (newLength > maxLength)
-					throw std::runtime_error("Ran out of space in payload string list");
-
-				// Copy over the null terminated string
-				stringValue.copy(rawValues + length, stringValue.length());
-				rawValues[newLength - 1] = 0;
-
-				length = newLength;
+		static std::string ToHex(std::string_view s, bool upper_case = true) {
+			std::ostringstream ret;
+			for (std::string::size_type i = 0; i < s.length(); ++i) {
+				int z = static_cast<unsigned char>(s[i]) & 0xff;
+				ret << std::hex << std::setfill('0') << std::setw(2) 
+					<< (upper_case ? std::uppercase : std::nouppercase) << z;
 			}
-
-			std::cout << "S2: " << length << std::endl;
+			return ret.str();
 		}
 
 		/// <summary>

--- a/code/monitor/host/windows/windows-monitor-process.h
+++ b/code/monitor/host/windows/windows-monitor-process.h
@@ -436,6 +436,13 @@ namespace Monitor::Windows {
 			length = 0;
 			rawValues[0] = 0;
 
+			auto set = PathSet::Build(values);
+
+			auto stream = std::stringstream();
+			set.Serialize(stream);
+
+			std::cout << "S1: " << stream.str().size() << std::endl;
+
 			for (auto value : values) {
 				auto stringValue = value.ToString();
 				auto newLength = length + static_cast<unsigned long>(stringValue.length()) + 1;
@@ -448,6 +455,8 @@ namespace Monitor::Windows {
 
 				length = newLength;
 			}
+
+			std::cout << "S2: " << length << std::endl;
 		}
 
 		/// <summary>

--- a/code/tools/bootstrap/package-lock.sml
+++ b/code/tools/bootstrap/package-lock.sml
@@ -16,7 +16,7 @@ Closure: {
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '2', Tool: '1' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '2', Tool: '1' }
 		'mwasplund|json11': { Version: 1.1.6, Digest: 'sha256:c6b0981921f926b73e9512d068efde6eb2c5183f6b3a8442bddc67f847d2bfc4', Build: '2', Tool: '1' }
-		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '2', Tool: '1' }
+		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '2', Tool: '1' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '2', Tool: '1' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '2', Tool: '1' }
 		sml: { Version: '../../sml/', Build: '2', Tool: '1' }

--- a/code/tools/bootstrap/package-lock.sml
+++ b/code/tools/bootstrap/package-lock.sml
@@ -16,7 +16,7 @@ Closure: {
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '2', Tool: '1' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '2', Tool: '1' }
 		'mwasplund|json11': { Version: 1.1.6, Digest: 'sha256:c6b0981921f926b73e9512d068efde6eb2c5183f6b3a8442bddc67f847d2bfc4', Build: '2', Tool: '1' }
-		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '2', Tool: '1' }
+		'mwasplund|opal': { Version: 0.13.8, Digest: 'sha256:a43a45de9efabdc5b6d204302d4309d00ab3c21d3cce0cfc2f136b1c652376b1', Build: '2', Tool: '1' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '2', Tool: '1' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '2', Tool: '1' }
 		sml: { Version: '../../sml/', Build: '2', Tool: '1' }

--- a/code/tools/bootstrap/package-lock.sml
+++ b/code/tools/bootstrap/package-lock.sml
@@ -13,7 +13,7 @@ Closure: {
 	'C++': {
 		'monitor-host': { Version: '../../monitor/host/', Build: '2', Tool: '1' }
 		'monitor-shared': { Version: '../../monitor/shared/', Build: '2', Tool: '1' }
-		'mwasplund|cryptopp': { Version: 1.2.9, Digest: 'sha256:53e593acbdfcaa81f285bcb64dabc3d38f36fd9bff7168d3c10a5d9ef752f446', Build: '2', Tool: '1' }
+		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '2', Tool: '1' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '2', Tool: '1' }
 		'mwasplund|json11': { Version: 1.1.6, Digest: 'sha256:c6b0981921f926b73e9512d068efde6eb2c5183f6b3a8442bddc67f847d2bfc4', Build: '2', Tool: '1' }
 		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '2', Tool: '1' }

--- a/code/tools/build-database/package-lock.sml
+++ b/code/tools/build-database/package-lock.sml
@@ -11,7 +11,7 @@ Closure: {
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|json11': { Version: 1.1.6, Digest: 'sha256:c6b0981921f926b73e9512d068efde6eb2c5183f6b3a8442bddc67f847d2bfc4', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.8, Digest: 'sha256:a43a45de9efabdc5b6d204302d4309d00ab3c21d3cce0cfc2f136b1c652376b1', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../../sml/', Build: '0', Tool: '0' }

--- a/code/tools/build-database/package-lock.sml
+++ b/code/tools/build-database/package-lock.sml
@@ -8,7 +8,7 @@ Closure: {
 		'build-database': { Version: './', Build: '0', Tool: '0' }
 		'monitor-host': { Version: '../../monitor/host/', Build: '0', Tool: '0' }
 		'monitor-shared': { Version: '../../monitor/shared/', Build: '0', Tool: '0' }
-		'mwasplund|cryptopp': { Version: 1.2.9, Digest: 'sha256:53e593acbdfcaa81f285bcb64dabc3d38f36fd9bff7168d3c10a5d9ef752f446', Build: '0', Tool: '0' }
+		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|json11': { Version: 1.1.6, Digest: 'sha256:c6b0981921f926b73e9512d068efde6eb2c5183f6b3a8442bddc67f847d2bfc4', Build: '0', Tool: '0' }
 		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }

--- a/code/tools/build-database/package-lock.sml
+++ b/code/tools/build-database/package-lock.sml
@@ -11,7 +11,7 @@ Closure: {
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|json11': { Version: 1.1.6, Digest: 'sha256:c6b0981921f926b73e9512d068efde6eb2c5183f6b3a8442bddc67f847d2bfc4', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../../sml/', Build: '0', Tool: '0' }

--- a/code/tools/mkdir/package-lock.sml
+++ b/code/tools/mkdir/package-lock.sml
@@ -2,7 +2,7 @@ Version: 6
 Closure: {
 	'C++': {
 		mkdir: { Version: './', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.8, Digest: 'sha256:a43a45de9efabdc5b6d204302d4309d00ab3c21d3cce0cfc2f136b1c652376b1', Build: '0', Tool: '0' }
 	}
 }
 Builds: {

--- a/code/tools/mkdir/package-lock.sml
+++ b/code/tools/mkdir/package-lock.sml
@@ -2,7 +2,7 @@ Version: 6
 Closure: {
 	'C++': {
 		mkdir: { Version: './', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
 	}
 }
 Builds: {

--- a/code/tools/print/package-lock.sml
+++ b/code/tools/print/package-lock.sml
@@ -7,7 +7,7 @@ Closure: {
 	'C++': {
 		'monitor-host': { Version: '../../monitor/host/', Build: '0', Tool: '0' }
 		'monitor-shared': { Version: '../../monitor/shared/', Build: '0', Tool: '0' }
-		'mwasplund|cryptopp': { Version: 1.2.9, Digest: 'sha256:53e593acbdfcaa81f285bcb64dabc3d38f36fd9bff7168d3c10a5d9ef752f446', Build: '0', Tool: '0' }
+		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
 		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }

--- a/code/tools/print/package-lock.sml
+++ b/code/tools/print/package-lock.sml
@@ -9,7 +9,7 @@ Closure: {
 		'monitor-shared': { Version: '../../monitor/shared/', Build: '0', Tool: '0' }
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.8, Digest: 'sha256:a43a45de9efabdc5b6d204302d4309d00ab3c21d3cce0cfc2f136b1c652376b1', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../../sml/', Build: '0', Tool: '0' }

--- a/code/tools/print/package-lock.sml
+++ b/code/tools/print/package-lock.sml
@@ -9,7 +9,7 @@ Closure: {
 		'monitor-shared': { Version: '../../monitor/shared/', Build: '0', Tool: '0' }
 		'mwasplund|cryptopp': { Version: 1.2.10, Digest: 'sha256:7a53c1ec24d6fd53ca3da5c34082a3ca3b31a82906b6223c6a177b7d8573ad73', Build: '0', Tool: '0' }
 		'mwasplund|detours': { Version: 4.0.15, Digest: 'sha256:1d482c600a7ac1acc36ea43c3d847451aeb5bf146312f40d351ec530c8c04746', Build: '0', Tool: '0' }
-		'mwasplund|opal': { Version: 0.13.5, Digest: 'sha256:44d81d4f032879ac74e753db438765829d6f4b512e68eacb990fb037f12b6e2a', Build: '0', Tool: '0' }
+		'mwasplund|opal': { Version: 0.13.6, Digest: 'sha256:10da1b08bd926efa18ab7710f6565f208745f7f915786dfea9e74eeb06cde3fa', Build: '0', Tool: '0' }
 		'mwasplund|reflex': { Version: 5.5.4, Digest: 'sha256:09e879b8c200c6415543686cf81c710712d07286753cdcd77cec08eab8e81bbe', Build: '0', Tool: '0' }
 		'mwasplund|soup-test-assert': { Version: 0.5.0, Digest: 'sha256:ae069ae6775ed31b5eb3ba5c05f33fd8e786cb77884991ae642b887cf7e0dde0', Build: '0', Tool: '0' }
 		sml: { Version: '../../sml/', Build: '0', Tool: '0' }

--- a/scripts/linux/soup
+++ b/scripts/linux/soup
@@ -11,11 +11,11 @@ RUN_DIR=$OUT_DIR/run
 BIN_DIR=$RUN_DIR/bin
 LIB_DIR=$RUN_DIR/lib/soup
 
-CONFIG_HASH=Oltq7cGwk0Rbgy1I-3mCMDDE5yM
+CONFIG_HASH=Oltq7cGwk0Rb
 
 OWNER=mwasplund
 
-SOUP_VERSION="0.48.0"
+SOUP_VERSION="0.48.1"
 
 # Cleanup previous runs
 rm -rf $RUN_DIR

--- a/scripts/linux/soupd
+++ b/scripts/linux/soupd
@@ -11,11 +11,11 @@ RUN_DIR=$OUT_DIR/run
 BIN_DIR=$RUN_DIR/bin
 LIB_DIR=$RUN_DIR/lib/soup
 
-CONFIG_HASH=OZlIVjblazFuKXg-raWUNoGEnG4
+CONFIG_HASH=OZlIVjblazFu
 
 OWNER=mwasplund
 
-SOUP_VERSION="0.48.0"
+SOUP_VERSION="0.48.1"
 
 # Cleanup previous runs
 rm -rf $RUN_DIR

--- a/scripts/windows/install.cmd
+++ b/scripts/windows/install.cmd
@@ -3,7 +3,7 @@ SET ScriptsDir=%~dp0
 SET RootDir=%ScriptsDir%..\..
 SET OutDir=%RootDir%\out
 
-SET SOUP_VERSION=0.48.0
+SET SOUP_VERSION=0.48.1
 
 pushd %OutDir%\release\%SOUP_VERSION%
 msiexec /package soup-build-windows-x64.msi /passive

--- a/scripts/windows/release.cmd
+++ b/scripts/windows/release.cmd
@@ -8,7 +8,7 @@ SET RunDir=%OutDir%\run
 SET CodeDir=%RootDir%\code
 SET InstallerDir=%CodeDir%\installer\soup-installer
 
-SET SOUP_VERSION=0.48.0
+SET SOUP_VERSION=0.48.1
 
 REM - Build MSI Installer
 echo msbuild %InstallerDir% -p:Configuration=Release

--- a/scripts/windows/sign-installer.cmd
+++ b/scripts/windows/sign-installer.cmd
@@ -4,7 +4,7 @@ SET ScriptsDir=%~dp0
 SET RootDir=%ScriptsDir%..\..
 SET OutDir=%RootDir%\out
 
-SET SOUP_VERSION=0.48.0
+SET SOUP_VERSION=0.48.1
 
 SET SIGN_COMMAND=signtool sign /n "Open Source Developer, Matthew Asplund" /t http://time.certum.pl /fd sha1 /v
 

--- a/scripts/windows/soup.cmd
+++ b/scripts/windows/soup.cmd
@@ -6,9 +6,9 @@ SET OutDir=%RootDir%\out
 SET MSBuildDir=%OutDir%\msbuild
 SET RunDir=%OutDir%\run
 
-SET ConfigHash=Oltq7cGwk0Rbgy1I-3mCMDDE5yM
+SET ConfigHash=Oltq7cGwk0Rb
 
-SET SOUP_VERSION=0.48.0
+SET SOUP_VERSION=0.48.1
 
 REM - Cleanup previous runs
 rmdir /S /Q %RunDir% > NUL

--- a/scripts/windows/soupd.cmd
+++ b/scripts/windows/soupd.cmd
@@ -6,9 +6,9 @@ SET OutDir=%RootDir%\out
 SET MSBuildDir=%OutDir%\msbuild
 SET RunDir=%OutDir%\run
 
-SET ConfigHash=OZlIVjblazFuKXg-raWUNoGEnG4
+SET ConfigHash=OZlIVjblazFu
 
-SET SOUP_VERSION=0.48.0
+SET SOUP_VERSION=0.48.1
 
 REM - Cleanup previous runs
 rmdir /S /Q %RunDir% > NUL


### PR DESCRIPTION
Shorten names and use path sets for sending to child process in windows to help limit the size of the detour payload.